### PR TITLE
perf: persistent worker pool and timer reuse for high-throughput batching

### DIFF
--- a/batcher.go
+++ b/batcher.go
@@ -84,6 +84,16 @@ type itemEnvelope[T any] struct {
 	sc   trace.SpanContext
 }
 
+// workItem is the payload handed from the worker goroutine to the persistent
+// dispatch pool created by SetMaxConcurrent. Bundling the trace links and
+// reason avoids per-batch closures and keeps observability intact for the
+// pool path.
+type workItem[T any] struct {
+	batch  []*T
+	links  []trace.Link
+	reason string
+}
+
 // Batcher is a generic batching utility that aggregates items and processes them in groups.
 //
 // The Batcher collects items of type T and invokes a processing function when either:
@@ -123,8 +133,14 @@ type Batcher[T any] struct {
 	done          chan struct{}
 	drainMode     atomic.Bool
 	maxConcurrent int
-	sem           chan struct{}
 	cfg           *config
+	// workCh is non-nil iff SetMaxConcurrent(n>0) was called. When non-nil,
+	// the worker dispatches batches to a fixed pool of N persistent goroutines
+	// over an unbuffered (rendezvous) channel — sender blocks until a worker
+	// is ready, providing the same backpressure as the previous semaphore.
+	// The worker goroutine is the sole sender; close happens after final-batch
+	// flush in the shutdown branch.
+	workCh chan workItem[T]
 }
 
 // New creates a new Batcher instance with the specified configuration.
@@ -338,20 +354,34 @@ func (b *Batcher[T]) SetDrainMode(enabled bool) {
 }
 
 // SetMaxConcurrent limits the number of concurrent in-flight background batch
-// processing goroutines. When the limit is reached, the worker blocks until a
-// slot is available, which naturally applies backpressure through the channel.
+// processing goroutines. When n>0 the batcher launches N persistent worker
+// goroutines that consume batches from an unbuffered channel; the worker
+// blocks on dispatch until one is ready, providing natural backpressure.
 //
 // This prevents unbounded goroutine accumulation when the batch processing
-// function (e.g., a gRPC call) is slower than the incoming item rate. Without
-// this limit, background=true causes the worker to spawn unlimited goroutines
-// that can exhaust memory.
+// function (e.g., a gRPC call) is slower than the incoming item rate, and
+// avoids spawning a fresh goroutine per batch on the hot path.
 //
-// A value of 0 (default) means no limit (original behavior).
+// A value of 0 (default) means no limit — batches dispatch on a fresh
+// goroutine each (the original unbounded-concurrency behavior).
 // Must be called before items are added to the batcher.
 func (b *Batcher[T]) SetMaxConcurrent(n int) {
-	if n > 0 {
-		b.maxConcurrent = n
-		b.sem = make(chan struct{}, n)
+	if n <= 0 {
+		return
+	}
+	b.maxConcurrent = n
+	b.workCh = make(chan workItem[T]) // rendezvous: backpressure equivalent to a size-N semaphore
+	b.cfg.logger.Infof("batcher %q: starting persistent worker pool of size %d", b.cfg.name, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			for w := range b.workCh {
+				b.dispatchAndRecord(w.batch, w.links, w.reason)
+				if b.usePool {
+					slice := w.batch[:0]
+					b.pool.Put(&slice)
+				}
+			}
+		}()
 	}
 }
 
@@ -412,6 +442,12 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 				b.cfg.logger.Infof("batcher %q: draining %d items on shutdown", b.cfg.name, len(b.batch))
 				b.dispatchAndRecord(b.batch, batchLinks, ReasonShutdown)
 			}
+			// We are the sole sender to workCh; closing here lets the
+			// persistent dispatch goroutines drain any in-flight batch and
+			// exit cleanly. No-op when SetMaxConcurrent was not configured.
+			if b.workCh != nil {
+				close(b.workCh)
+			}
 			return
 
 		case env := <-b.ch:
@@ -438,9 +474,16 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 				goto saveBatch
 			}
 
-			// Lazy timer activation: start on first item only.
+			// Lazy timer activation: start on first item only. Reuse the same
+			// Timer across batches to avoid a per-batch allocation; safe under
+			// Go 1.23+ semantics where Reset on a stopped/expired timer will
+			// not deliver a stale value.
 			if len(b.batch) == 1 {
-				timer = time.NewTimer(b.timeout)
+				if timer == nil {
+					timer = time.NewTimer(b.timeout)
+				} else {
+					timer.Reset(b.timeout)
+				}
 				timerCh = timer.C
 			}
 
@@ -475,39 +518,35 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 			links := batchLinks
 
 			if b.background {
-				// Acquire semaphore slot if max concurrent is set.
-				if b.sem != nil {
+				if b.workCh != nil {
+					// Hand the batch to a persistent worker. The unbuffered
+					// channel blocks here when all N workers are busy,
+					// applying backpressure up through b.ch and Put().
 					semStart := time.Now()
 					select {
-					case b.sem <- struct{}{}:
+					case b.workCh <- workItem[T]{batch: batch, links: links, reason: reason}:
 						if wait := time.Since(semStart); wait > time.Microsecond {
 							b.cfg.metricsBound.BackpressureWait(wait)
 						}
 					case <-b.done:
-						// Shutdown while waiting for semaphore — process synchronously.
+						// Shutdown while waiting for a worker — process synchronously.
+						b.cfg.logger.Warnf("batcher %q: dispatching batch of %d items inline due to shutdown while waiting for worker slot", b.cfg.name, len(batch))
 						b.dispatchAndRecord(batch, links, reason)
+						if b.usePool {
+							slice := batch[:0]
+							b.pool.Put(&slice)
+						}
 						return
 					}
-				}
-
-				if b.usePool {
+				} else if b.usePool {
+					// Unbounded concurrency path: spawn a fresh goroutine per batch.
 					go func(batch []*T, links []trace.Link, reason string) {
-						defer func() {
-							if b.sem != nil {
-								<-b.sem
-							}
-						}()
 						b.dispatchAndRecord(batch, links, reason)
 						slice := batch[:0]
 						b.pool.Put(&slice)
 					}(batch, links, reason)
 				} else {
 					go func(batch []*T, links []trace.Link, reason string) {
-						defer func() {
-							if b.sem != nil {
-								<-b.sem
-							}
-						}()
 						b.dispatchAndRecord(batch, links, reason)
 					}(batch, links, reason)
 				}

--- a/batcher_test.go
+++ b/batcher_test.go
@@ -735,7 +735,7 @@ func TestSetMaxConcurrent_ZeroNoLimit(t *testing.T) {
 	}, true)
 	b.SetMaxConcurrent(0) // Should be a no-op
 
-	assert.Nil(t, b.sem, "Semaphore should not be created for maxConcurrent=0")
+	assert.Nil(t, b.workCh, "Worker pool should not be created for maxConcurrent=0")
 
 	for i := 0; i < 5; i++ {
 		b.Put(&batchStoreItem{})


### PR DESCRIPTION
## Summary

Two micro-architectural changes to `Batcher[T]` that reduce per-batch overhead at high throughput, with no public API change and equivalent backpressure / shutdown semantics. Stacked on top of #98 (now merged).

1. **Persistent worker pool when `SetMaxConcurrent(n>0)`.** Replace the per-batch `go func{ acquire sem; b.fn; release sem }` pattern with N persistent worker goroutines fed by an unbuffered (rendezvous) `chan workItem[T]`. Eliminates `runtime.newproc` and stack growth on every batch dispatch.
2. **Reuse the worker's lazy `time.Timer`** via `Reset` instead of allocating a fresh `time.NewTimer` on the first item of every batch. Aligns the implementation with the `worker()` doc comment that already claims "Reuses timers to reduce allocations and GC pressure".

## Changes

### `batcher.go`

**Struct.** Dropped `sem chan struct{}`. Added `workCh chan workItem[T]` (non-nil iff `SetMaxConcurrent(n>0)`). New `workItem[T]` payload carries `batch / links / reason` so the persistent workers preserve full observability context — they go through `dispatchAndRecord` rather than calling `b.fn` directly.

**`SetMaxConcurrent(n)`.** When `n>0`, creates an unbuffered `workCh` and spawns N persistent workers:
```go
b.workCh = make(chan workItem[T])
b.cfg.logger.Infof("batcher %q: starting persistent worker pool of size %d", b.cfg.name, n)
for i := 0; i < n; i++ {
    go func() {
        for w := range b.workCh {
            b.dispatchAndRecord(w.batch, w.links, w.reason)
            if b.usePool {
                slice := w.batch[:0]
                b.pool.Put(&slice)
            }
        }
    }()
}
```
`n<=0` is now an explicit no-op — preserves the original unbounded-concurrency path (per-batch goroutine spawn) and keeps `TestSetMaxConcurrent_ZeroNoLimit` passing.

**`saveBatch` dispatch (background path).** Branch on `b.workCh != nil`:
```go
if b.workCh != nil {
    semStart := time.Now()
    select {
    case b.workCh <- workItem[T]{batch: batch, links: links, reason: reason}:
        if wait := time.Since(semStart); wait > time.Microsecond {
            b.cfg.metricsBound.BackpressureWait(wait)
        }
    case <-b.done:
        b.cfg.logger.Warnf("batcher %q: dispatching batch of %d items inline due to shutdown while waiting for worker slot", b.cfg.name, len(batch))
        b.dispatchAndRecord(batch, links, reason)
        if b.usePool {
            slice := batch[:0]
            b.pool.Put(&slice)
        }
        return
    }
} else if b.usePool { ... per-batch goroutine ... } else { ... per-batch goroutine ... }
```
The `BackpressureWait` metric instrumentation is preserved verbatim from the old `b.sem <- struct{}{}` acquire path.

**Worker shutdown branch.** After the synchronous final-batch flush, `close(b.workCh)` so persistent workers drain any in-flight `workItem` and exit. The worker goroutine is the sole sender, so close-after-drain is race-free.

**Timer reuse.** Lazy timer activation now `Reset`s an existing timer instead of allocating a new one:
```go
if len(b.batch) == 1 {
    if timer == nil {
        timer = time.NewTimer(b.timeout)
    } else {
        timer.Reset(b.timeout)
    }
    timerCh = timer.C
}
```
Safe under Go 1.23+ semantics where `Reset` on a stopped/expired timer cannot deliver a stale value (we're on Go 1.25).

### `batcher_test.go`

`TestSetMaxConcurrent_ZeroNoLimit` updated to assert `b.workCh == nil` (the new gate) instead of the removed `b.sem`.

## Why an unbuffered (rendezvous) `workCh`, not a buffer of `n`?

A buffered channel of `n` would allow up to `n` parked batches plus `n` in-flight = peak `2n` batches in memory. At "millions of items/sec" with non-trivial batch sizes that's real RAM. Unbuffered preserves exact semantic equivalence with the size-`n` semaphore the code used before: the worker blocks on dispatch until a goroutine is ready. Throughput is unaffected — workers are always-ready and the rendezvous handoff is sub-microsecond.

## Why route persistent workers through `dispatchAndRecord` instead of calling `b.fn` directly?

`dispatchAndRecord` is the observability seam. It emits the OpenTelemetry span (with `batcher.name / batcher.batch_size / batcher.reason` attributes and any captured `links`), records `BatchTriggered` / `BatchProcessed` / `PanicRecovered` metrics, and recovers from `b.fn` panics so the worker survives. Routing pool workers through the same path keeps observability identical between the `n==0` fallback and the `n>0` persistent-pool path.

## Observability audit

All existing hooks fire on every new code path:

| Hook                   | Path                                                                                  |
|------------------------|---------------------------------------------------------------------------------------|
| `Enqueued()`           | unchanged — `Put` / `PutCtx` → `enqueue`                                              |
| `EnqueueBlocked(d)`    | unchanged — backpressure now propagates `workCh` → `b.ch` fills → `Put` blocks       |
| `BatchTriggered(reason)` | `dispatchAndRecord` (pool worker, n==0 goroutine, sync shutdown fallback, fg path) |
| `BatchProcessed(size, dur)` | `dispatchAndRecord` defer                                                       |
| `BackpressureWait(d)`  | recorded on `b.workCh <- workItem{...}` send wait                                    |
| `PanicRecovered()`     | `dispatchAndRecord` defer (covers all dispatch paths including pool workers)         |
| Span + links + reason  | `dispatchAndRecord` (emitted on every dispatch path)                                 |

**Two small additions in this PR (no `BoundMetrics` interface change):**
- `Infof` log when the persistent pool starts, symmetrical with the existing `"draining %d items on shutdown"`.
- `Warnf` log when a batch is dispatched inline because `Close()` happened while waiting for a worker slot — the documented edge case exercised by `TestSetMaxConcurrent_CloseWhileBlocked`.

**Considered but deferred** (would require extending the `BoundMetrics` interface, separate PR):
- `WorkersInFlight` gauge — combined with `BackpressureWait` it would tell operators when pool capacity is the bottleneck.
- `ShutdownInline` counter for the close-while-blocked dispatch path.

## Behavioral guarantees preserved

- Peak concurrency `≤ maxConcurrent` (verified by `TestSetMaxConcurrent_Limits`).
- `n=0` means unbounded concurrency (verified by `TestSetMaxConcurrent_ZeroNoLimit`).
- `Close()` while the worker is blocked on dispatch does not deadlock (verified by `TestSetMaxConcurrent_CloseWhileBlocked` — `select` on `b.done` in the dispatch send is preserved).
- No goroutine leaks across many open/close cycles (verified by `TestBatcherResourceCleanup` — persistent workers exit when `workCh` closes in the shutdown branch).
- Backpressure metric (`BackpressureWait`) emitted on dispatch wait, same as the old semaphore acquire path.
- Public API unchanged.

## Test plan

- [x] `go test -race -count=1 -timeout=240s ./...` — all green (~32s, includes `TestSetMaxConcurrent_*`, `TestBatcherResourceCleanup`, dedup, drain mode, integration).
- [x] `go build ./...` clean.
- [x] Existing benchmark drop on `BenchmarkBatcherPut`: 11 → 8 B/op (the eliminated `time.Timer` allocation, ~24 B amortized over the batch).
- [ ] Reviewer to spot-check that `dispatchAndRecord` is invoked from every dispatch path: pool worker loop, `n==0` per-batch goroutine (pool & non-pool), synchronous `<-b.done` shutdown fallback, non-`background` foreground path.
- [ ] Reviewer to confirm the rendezvous-channel choice over a buffered one is the right tradeoff for this codebase.

## Out of scope (deliberately, separate PRs)

- **Sharded input channel.** `b.ch` is `chan itemEnvelope[T]` and at very high producer counts the channel mutex becomes the bottleneck. Splitting into per-P shards is the next big win but a much larger change.
- **Latent "Close drops items still queued in `b.ch` when worker is blocked on dispatch" bug** — preserved from existing master, not introduced here.
- **`WorkersInFlight` gauge** — requires a `BoundMetrics` interface change; worth doing once we agree on the API surface.
- **Adding a benchmark that actually exercises `SetMaxConcurrent`.** None exist today, so the worker-pool win can't be measured against the existing suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)