### PR TITLE
feat: block in Close() until in-flight batches are drained

### DIFF
--- a/batcher.go
+++ b/batcher.go
@@ -152,6 +152,24 @@ type Batcher[T any] struct {
 	// ticker via SetTickInterval at any time without a data race. Atomic load on the
 	// hot path is a sub-nanosecond cost.
 	ticker atomic.Pointer[time.Ticker]
+
+	// finished is closed by the worker goroutine when it has fully returned —
+	// i.e. after the shutdown drain has dispatched the residual batch AND all
+	// background dispatch goroutines have completed (see inflight). Close()
+	// blocks on this channel so callers can rely on every queued item having
+	// been handed to fn before Close returns.
+	finished chan struct{}
+	// inflight counts background batch dispatches that run on goroutines other
+	// than the worker (the fresh-goroutine paths and the persistent worker
+	// pool). The worker waits on it during shutdown so Close does not return
+	// while a background fn call is still writing. Add happens on the worker
+	// goroutine before the dispatch is handed off; Done happens when fn
+	// returns. Synchronous dispatches (non-background, and the shutdown drain
+	// itself) run inline on the worker and need no tracking.
+	inflight sync.WaitGroup
+	// closeOnce guards close(done) so Close is idempotent — a second call must
+	// not panic with "close of closed channel".
+	closeOnce sync.Once
 }
 
 // New creates a new Batcher instance with the specified configuration.
@@ -191,6 +209,7 @@ func New[T any](size int, timeout time.Duration, fn func(batch []*T), background
 		background: background,
 		usePool:    false,
 		done:       make(chan struct{}),
+		finished:   make(chan struct{}),
 		cfg:        applyOptions(opts),
 	}
 
@@ -230,8 +249,9 @@ func NewWithPool[T any](size int, timeout time.Duration, fn func(batch []*T), ba
 				return &slice
 			},
 		},
-		done: make(chan struct{}),
-		cfg:  applyOptions(opts),
+		done:     make(chan struct{}),
+		finished: make(chan struct{}),
+		cfg:      applyOptions(opts),
 	}
 
 	go b.worker()
@@ -342,13 +362,26 @@ func (b *Batcher[T]) Trigger() {
 //   - The internal channel is closed after draining, preventing further Put() calls
 //
 // Notes:
-//   - This method returns immediately without waiting for shutdown to complete
+//   - This method BLOCKS until shutdown is complete: the worker has drained the
+//     channel, dispatched the residual batch through fn, and every background
+//     dispatch goroutine has finished. On return, all items accepted before
+//     Close have been handed to fn. Bound the wait with your own timeout
+//     (e.g. run Close in a goroutine and select on a context) if fn can hang.
+//   - Close is idempotent: calling it more than once is safe and will not panic.
+//     Concurrent callers all block until shutdown completes.
 //
 // IMPORTANT: Do not call Put() / PutCtx() after Close() has been called. The
 // channel is closed during shutdown, and any further send will panic with
 // "send on closed channel". Callers must ensure proper synchronization.
 func (b *Batcher[T]) Close() {
-	close(b.done)
+	b.closeOnce.Do(func() {
+		close(b.done)
+	})
+	// Wait for the worker to fully unwind. finished is closed only after the
+	// shutdown drain and inflight.Wait() in worker(), so a returned Close
+	// guarantees every queued item has been handed to fn. Receiving from a
+	// closed channel returns immediately, so repeat/concurrent callers are fine.
+	<-b.finished
 }
 
 // SetDrainMode enables or disables drain mode.
@@ -400,6 +433,9 @@ func (b *Batcher[T]) SetMaxConcurrent(n int) {
 					b.pool.Put(&slice)
 				}
 				b.cfg.metricsBound.WorkerFinished()
+				// Pairs with the inflight.Add issued by the worker before it
+				// handed this batch over the rendezvous channel.
+				b.inflight.Done()
 			}
 		}()
 	}
@@ -468,6 +504,13 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 	var timer *time.Timer
 	var timerCh <-chan time.Time // nil channel blocks forever, enabling lazy timer activation
 	var batchLinks []trace.Link
+
+	// Registered first so they run last (LIFO): on any worker return, first
+	// wait for outstanding background dispatches to finish (inflight), then
+	// signal Close() that shutdown is fully complete (finished). This pairing
+	// is what lets Close block until every queued item has been handed to fn.
+	defer close(b.finished)
+	defer b.inflight.Wait()
 
 	defer func() {
 		if timer != nil {
@@ -617,6 +660,13 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 			links := batchLinks
 
 			if b.background {
+				// Track this dispatch so the shutdown drain (inflight.Wait in
+				// worker) blocks until fn has actually run. Add is always on the
+				// worker goroutine, so it never races the Wait that also runs
+				// there; Done is paired below (persistent worker, fresh
+				// goroutine, or the inline shutdown path).
+				b.inflight.Add(1)
+
 				if b.workCh != nil {
 					// Hand the batch to a persistent worker. The unbuffered
 					// channel blocks here when all N workers are busy,
@@ -627,6 +677,7 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 						if wait := time.Since(semStart); wait > time.Microsecond {
 							b.cfg.metricsBound.BackpressureWait(wait)
 						}
+						// persistent worker calls inflight.Done after dispatch
 					case <-b.done:
 						// Shutdown while waiting for a worker — process synchronously.
 						b.cfg.logger.Warnf("batcher %q: dispatching batch of %d items inline due to shutdown while waiting for worker slot", b.cfg.name, len(batch))
@@ -635,17 +686,20 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 							slice := batch[:0]
 							b.pool.Put(&slice)
 						}
+						b.inflight.Done()
 						return
 					}
 				} else if b.usePool {
 					// Unbounded concurrency path: spawn a fresh goroutine per batch.
 					go func(batch []*T, links []trace.Link, reason string) {
+						defer b.inflight.Done()
 						b.dispatchAndRecord(batch, links, reason)
 						slice := batch[:0]
 						b.pool.Put(&slice)
 					}(batch, links, reason)
 				} else {
 					go func(batch []*T, links []trace.Link, reason string) {
+						defer b.inflight.Done()
 						b.dispatchAndRecord(batch, links, reason)
 					}(batch, links, reason)
 				}

--- a/batcher_close_drain_test.go
+++ b/batcher_close_drain_test.go
@@ -1,0 +1,87 @@
+package batcher
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCloseBlocksUntilBackgroundDrainComplete verifies the core shutdown
+// contract: Close must not return until every item accepted before Close has
+// been handed to fn — including items dispatched on background goroutines with
+// a slow callback. This is the guarantee teranode's UTXO store relies on to
+// flush in-flight batched writes on SIGTERM. Against the old fire-and-forget
+// Close (close(b.done) only) this test fails: Close returns before the slow
+// background fn finishes, so processed < total.
+func TestCloseBlocksUntilBackgroundDrainComplete(t *testing.T) {
+	const total = 500
+
+	var processed atomic.Int64
+
+	// background=true, slow callback so the residual batch is still being
+	// written when Close is called.
+	b := New(16, 50*time.Millisecond, func(batch []*int) {
+		time.Sleep(5 * time.Millisecond)
+		processed.Add(int64(len(batch)))
+	}, true, WithName("close_drain"))
+
+	for i := 0; i < total; i++ {
+		v := i
+		b.Put(&v)
+	}
+
+	b.Close()
+
+	if got := processed.Load(); got != total {
+		t.Fatalf("Close returned before drain completed: processed %d, want %d", got, total)
+	}
+}
+
+// TestCloseIsIdempotent verifies Close can be called more than once without
+// panicking on "close of closed channel" and that repeat calls still return
+// only after shutdown is complete.
+func TestCloseIsIdempotent(t *testing.T) {
+	var processed atomic.Int64
+
+	b := New(8, 20*time.Millisecond, func(batch []*int) {
+		processed.Add(int64(len(batch)))
+	}, true, WithName("close_idempotent"))
+
+	for i := 0; i < 32; i++ {
+		v := i
+		b.Put(&v)
+	}
+
+	b.Close()
+	b.Close() // must not panic
+	b.Close() // must not panic
+
+	if got := processed.Load(); got != 32 {
+		t.Fatalf("processed %d, want 32", got)
+	}
+}
+
+// TestCloseDrainPooledBackground exercises the NewWithPool background path,
+// which dispatches each batch on a fresh goroutine, to confirm those
+// goroutines are also awaited by Close.
+func TestCloseDrainPooledBackground(t *testing.T) {
+	const total = 300
+
+	var processed atomic.Int64
+
+	b := NewWithPool(10, 50*time.Millisecond, func(batch []*int) {
+		time.Sleep(2 * time.Millisecond)
+		processed.Add(int64(len(batch)))
+	}, true, WithName("close_drain_pool"))
+
+	for i := 0; i < total; i++ {
+		v := i
+		b.Put(&v)
+	}
+
+	b.Close()
+
+	if got := processed.Load(); got != total {
+		t.Fatalf("pooled background drain incomplete: processed %d, want %d", got, total)
+	}
+}

--- a/batcher_deduplication.go
+++ b/batcher_deduplication.go
@@ -767,6 +767,7 @@ func NewWithDeduplication[T comparable](size int, timeout time.Duration, fn func
 			background: background,
 			usePool:    false,
 			done:       make(chan struct{}),
+			finished:   make(chan struct{}),
 			cfg:        applyOptions(opts),
 		},
 		deduplicationWindow: deduplicationWindow,
@@ -794,6 +795,7 @@ func NewWithDeduplicationAndPool[T comparable](size int, timeout time.Duration, 
 			background: background,
 			usePool:    true,
 			done:       make(chan struct{}),
+			finished:   make(chan struct{}),
 			pool: &sync.Pool{
 				New: func() interface{} {
 					slice := make([]*T, 0, size)


### PR DESCRIPTION
## Problem

`Close()` is currently fire-and-forget:

```go
func (b *Batcher[T]) Close() {
    close(b.done)
}
```

It signals the worker to drain, then returns immediately — the doc comment even says so ("returns immediately without waiting for shutdown to complete"). The worker drains the channel and dispatches the residual batch on **its own goroutine**, and background batches dispatch on **further goroutines** (the fresh-goroutine paths and the persistent worker pool). The caller has no way to know when any of that has finished.

That's a correctness hazard for any caller that needs durability on shutdown. Concretely, a UTXO store in [teranode](https://github.com/bsv-blockchain/teranode) fronts its DB/Aerospike writes with background batchers. On SIGTERM it calls `Close()` and then closes the DB/client — but because `Close()` returns before the drain runs, the connection is torn down while the worker is still dispatching, silently losing writes the caller already received a success ack for. On restart, blocks that spend those UTXOs fail with missing-parent errors.

## Change

Make `Close()` **block until shutdown is fully complete**:

- The worker signals a new `finished` channel on return, and first waits on an `inflight` `sync.WaitGroup` that tracks every background dispatch (fresh-goroutine paths + persistent worker pool). `Add` happens on the worker goroutine before hand-off (so it never races the `Wait`, which also runs there); `Done` happens when `fn` returns.
- `Close()` waits on `finished`, so on return **every item accepted before `Close` has been handed to `fn`**.
- `Close()` is now **idempotent** via `sync.Once` — repeat/concurrent calls no longer panic with "close of closed channel".

Non-background (synchronous) dispatch and the inline shutdown drain run on the worker itself, so they're covered without tracking — the hot path is unchanged.

Callers that need to bound the wait (e.g. if `fn` can hang) should run `Close()` in a goroutine and select on a context — documented on the method.

## Tests

Adds `batcher_close_drain_test.go`:
- `TestCloseBlocksUntilBackgroundDrainComplete` — slow background `fn`, asserts all items processed after `Close` returns. **Fails against the old fire-and-forget `Close` (`processed 0, want 500`)**, passes now.
- `TestCloseIsIdempotent` — multiple `Close()` calls don't panic.
- `TestCloseDrainPooledBackground` — covers the `NewWithPool` fresh-goroutine path.

`go vet ./...` clean, `gofmt` clean, `go test -race ./...` → **190 pass** (187 existing + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)