### PR TITLE
Group-completion primitive, PutBatch, and greedy accumulate

### DIFF
--- a/batcher.go
+++ b/batcher.go
@@ -336,8 +336,13 @@ func (b *Batcher[T]) PutCtx(ctx context.Context, item *T, _ ...int) {
 // The group is treated as an ordered unit by the collector: if it is smaller
 // than the configured batch size it simply accumulates like N individual
 // Put calls; if appending it would exceed the size cap, the collector splits
-// it into full-size batches (each dispatched immediately, in order) plus at
-// most one trailing partial batch that continues accumulating normally.
+// it into full-size batches (each handed to fn in order) plus at most one
+// trailing partial batch that continues accumulating normally. Item order is
+// preserved across the split. Note that "in order" refers to dispatch order:
+// with background=true (and especially without SetMaxConcurrent) each split
+// batch runs fn on its own goroutine, so cross-batch fn completion order is
+// not guaranteed — only item order within a batch, and the order in which
+// batches are handed off, are.
 // Batch size is always honored — a PutBatch call never produces a batch
 // larger than the batcher's configured size, even when len(items) > size.
 //
@@ -397,7 +402,15 @@ func (b *Batcher[T]) PutBatchCtx(ctx context.Context, items []*T, _ ...int) {
 // fallback when the buffer is full so the common case is allocation- and
 // timer-free.
 func (b *Batcher[T]) enqueue(env itemEnvelope[T]) {
-	b.cfg.metricsBound.Enqueued()
+	// enqueued_total counts items submitted, so a PutBatch envelope accounts
+	// for its whole group — not one per channel send — to avoid undercounting.
+	if n := len(env.items); n > 0 {
+		for i := 0; i < n; i++ {
+			b.cfg.metricsBound.Enqueued()
+		}
+	} else {
+		b.cfg.metricsBound.Enqueued()
+	}
 	select {
 	case b.ch <- env:
 		return

--- a/batcher.go
+++ b/batcher.go
@@ -176,6 +176,11 @@ type Batcher[T any] struct {
 	// closeOnce guards close(done) so Close is idempotent — a second call must
 	// not panic with "close of closed channel".
 	closeOnce sync.Once
+	// modeMu serializes the mutually-exclusive mode setters (SetDrainMode,
+	// SetGreedyAccumulate, SetTickInterval) so their check-then-set on the
+	// independent mode atomics is linearizable — concurrent calls can no longer
+	// interleave two checks before either store and leave conflicting modes on.
+	modeMu sync.Mutex
 }
 
 // New creates a new Batcher instance with the specified configuration.
@@ -205,6 +210,9 @@ type Batcher[T any] struct {
 //   - The batch slice is pre-allocated with the specified size for efficiency
 //   - Passing background=true is recommended for I/O-bound operations to avoid blocking
 func New[T any](size int, timeout time.Duration, fn func(batch []*T), background bool, opts ...Option) *Batcher[T] {
+	if size <= 0 {
+		panic("batcher: size must be greater than 0")
+	}
 	b := &Batcher[T]{
 		fn:         fn,
 		size:       size,
@@ -243,6 +251,9 @@ func New[T any](size int, timeout time.Duration, fn func(batch []*T), background
 // Returns:
 //   - *Batcher[T]: A configured and running Batcher instance with pooling enabled
 func NewWithPool[T any](size int, timeout time.Duration, fn func(batch []*T), background bool, opts ...Option) *Batcher[T] {
+	if size <= 0 {
+		panic("batcher: size must be greater than 0")
+	}
 	b := &Batcher[T]{
 		fn:         fn,
 		size:       size,
@@ -334,6 +345,19 @@ func (b *Batcher[T]) PutCtx(ctx context.Context, item *T, _ ...int) {
 // you want linked to the eventual batch span(s). Passing a nil or empty
 // slice is a no-op.
 //
+// PutBatch snapshots the slice: the pointers are copied into an internal
+// buffer before the call returns, so the caller is free to reuse, pool, or
+// overwrite the slice immediately afterward. The pointed-to items themselves
+// are shared, exactly as with Put — do not mutate an item after enqueuing it.
+//
+// A group larger than the batch size is split and dispatched by the single
+// worker goroutine as ceil(len(items)/size) batches. That work is done in one
+// pass: with background=true it is spread across the dispatch pool, but with
+// background=false each split batch runs fn inline on the worker, so a single
+// very large PutBatch can keep the worker (and therefore Trigger/timeouts)
+// busy for len(items)/size × fn-duration. Prefer sizes that keep any one call
+// bounded, or use background dispatch, for very large groups.
+//
 // Parameters:
 //   - items: The group of items to enqueue together. Must not contain nil pointers.
 //   - _: Variadic int parameter for payload size (ignored, kept for API compatibility)
@@ -341,7 +365,12 @@ func (b *Batcher[T]) PutBatch(items []*T, _ ...int) {
 	if len(items) == 0 {
 		return
 	}
-	b.enqueue(itemEnvelope[T]{items: items})
+	// Snapshot the caller's slice: the worker reads it later on its own
+	// goroutine, so retaining the caller's backing array would race a caller
+	// that reuses or pools the slice after this call returns.
+	snapshot := make([]*T, len(items))
+	copy(snapshot, items)
+	b.enqueue(itemEnvelope[T]{items: snapshot})
 }
 
 // PutBatchCtx is like PutBatch but captures the SpanContext from ctx so the
@@ -354,8 +383,11 @@ func (b *Batcher[T]) PutBatchCtx(ctx context.Context, items []*T, _ ...int) {
 	if len(items) == 0 {
 		return
 	}
+	// See PutBatch: snapshot so the caller may reuse the slice after the call.
+	snapshot := make([]*T, len(items))
+	copy(snapshot, items)
 	b.enqueue(itemEnvelope[T]{
-		items: items,
+		items: snapshot,
 		sc:    trace.SpanContextFromContext(ctx),
 	})
 }
@@ -427,9 +459,10 @@ func (b *Batcher[T]) Trigger() {
 //   - Close is idempotent: calling it more than once is safe and will not panic.
 //     Concurrent callers all block until shutdown completes.
 //
-// IMPORTANT: Do not call Put() / PutCtx() after Close() has been called. The
-// channel is closed during shutdown, and any further send will panic with
-// "send on closed channel". Callers must ensure proper synchronization.
+// IMPORTANT: Do not call Put() / PutCtx() / PutBatch() / PutBatchCtx() after
+// Close() has been called. The channel is closed during shutdown, and any
+// further send will panic with "send on closed channel". Callers must ensure
+// proper synchronization.
 func (b *Batcher[T]) Close() {
 	b.closeOnce.Do(func() {
 		close(b.done)
@@ -451,6 +484,8 @@ func (b *Batcher[T]) Close() {
 // at low throughput, batches are small (even single-item) with near-zero latency;
 // at high throughput, batches grow larger as more items queue during processing.
 func (b *Batcher[T]) SetDrainMode(enabled bool) {
+	b.modeMu.Lock()
+	defer b.modeMu.Unlock()
 	if enabled && b.ticker.Load() != nil {
 		b.cfg.logger.Warnf("batcher %q: SetDrainMode(true) rejected — tick mode is enabled", b.cfg.name)
 		return
@@ -481,6 +516,8 @@ func (b *Batcher[T]) SetDrainMode(enabled bool) {
 // though changing it once items are already flowing does not retroactively
 // affect an in-progress accumulation cycle.
 func (b *Batcher[T]) SetGreedyAccumulate(enabled bool) {
+	b.modeMu.Lock()
+	defer b.modeMu.Unlock()
 	if enabled && b.drainMode.Load() {
 		b.cfg.logger.Warnf("batcher %q: SetGreedyAccumulate(true) rejected — drain mode is enabled", b.cfg.name)
 		return
@@ -549,6 +586,8 @@ func (b *Batcher[T]) SetTickInterval(d time.Duration) {
 	if d <= 0 {
 		return
 	}
+	b.modeMu.Lock()
+	defer b.modeMu.Unlock()
 	if b.drainMode.Load() {
 		b.cfg.logger.Warnf("batcher %q: SetTickInterval rejected — drain mode is enabled", b.cfg.name)
 		return
@@ -613,6 +652,10 @@ func (b *Batcher[T]) flushBatch(reason string, batchLinks []trace.Link) (newBatc
 					b.pool.Put(&slice)
 				}
 				b.inflight.Done()
+				// This batch has been dispatched; clear b.batch so the caller
+				// (appendItems) can preserve any not-yet-appended remainder of
+				// an oversized PutBatch without re-dispatching these items.
+				b.batch = nil
 				return nil, true
 			}
 		} else if b.usePool {
@@ -687,6 +730,10 @@ func (b *Batcher[T]) appendItems(items []*T, batchLinks []trace.Link) (newBatchL
 			batchLinks, exit = b.flushBatch(ReasonSize, batchLinks)
 			flushed = true
 			if exit {
+				// flushBatch cleared b.batch on the shutdown-race path; keep the
+				// not-yet-appended remainder so the shutdown drain still delivers
+				// it instead of silently dropping it.
+				b.batch = append(b.batch, items...)
 				return batchLinks, flushed, true
 			}
 			room = b.size
@@ -704,12 +751,73 @@ func (b *Batcher[T]) appendItems(items []*T, batchLinks []trace.Link) (newBatchL
 			batchLinks, exit = b.flushBatch(ReasonSize, batchLinks)
 			flushed = true
 			if exit {
+				b.batch = append(b.batch, items...)
 				return batchLinks, flushed, true
+			}
+			// Interruption point: once shutdown has begun, stop splitting a
+			// large group synchronously here and hand the remainder to the
+			// shutdown drain, so a single oversized PutBatch cannot keep the
+			// worker from acknowledging Close for len(items)/size flushes.
+			select {
+			case <-b.done:
+				b.batch = append(b.batch, items...)
+				return batchLinks, flushed, true
+			default:
 			}
 		}
 	}
 
 	return batchLinks, flushed, false
+}
+
+// drainOnShutdown is the single terminal path taken whenever the worker stops.
+// It is called with b.done already closed, so no further live dispatching can
+// happen. It closes b.ch, drains any envelopes still buffered there into
+// b.batch, then dispatches everything held — the residual partial batch plus
+// the drained remainder — synchronously and in size-capped chunks so a queued
+// PutBatch envelope (or any accumulated batch) never hands fn more than the
+// configured size on the shutdown path either. Finally it closes the
+// persistent worker pool so its goroutines exit.
+//
+// It must be called exactly once, immediately before worker() returns, on every
+// exit path — including the flushBatch/appendItems exit=true (shutdown-race)
+// paths, which previously returned directly and leaked the pool goroutines by
+// never closing workCh.
+func (b *Batcher[T]) drainOnShutdown(batchLinks []trace.Link) { //nolint:gocognit // Terminal drain: close, drain, size-capped dispatch, pool close — each a single guarded step on the one shutdown path
+	close(b.ch)
+	for env := range b.ch {
+		if env.items != nil {
+			b.batch = append(b.batch, env.items...)
+		} else {
+			b.batch = append(b.batch, env.item)
+		}
+		if env.sc.IsValid() {
+			batchLinks = append(batchLinks, trace.Link{SpanContext: env.sc})
+		}
+	}
+
+	if len(b.batch) > 0 {
+		b.cfg.logger.Infof("batcher %q: draining %d items on shutdown", b.cfg.name, len(b.batch))
+	}
+	// Dispatch synchronously in chunks of at most b.size. Because each dispatch
+	// is synchronous, fn has returned before we advance b.batch, so reslicing
+	// the backing array is safe and no inflight tracking is needed.
+	for len(b.batch) > 0 {
+		n := b.size
+		if n > len(b.batch) {
+			n = len(b.batch)
+		}
+		b.dispatchAndRecord(b.batch[:n:n], batchLinks, ReasonShutdown)
+		b.batch = b.batch[n:]
+		batchLinks = nil // the span link travels with the first chunk only
+	}
+
+	// We are the sole sender to workCh; closing here lets the persistent
+	// dispatch goroutines drain any in-flight batch and exit cleanly. No-op
+	// when SetMaxConcurrent was not configured.
+	if b.workCh != nil {
+		close(b.workCh)
+	}
 }
 
 // worker is the core processing loop that manages batch aggregation and processing.
@@ -774,33 +882,9 @@ workerLoop:
 	for {
 		select {
 		case <-b.done:
-			// Shutdown: drain channel and process remaining items. This
-			// residual dispatch already ignores the size cap for ordinary
-			// single-item accumulation (it flushes whatever piled up between
-			// the done-signal and the channel fully draining), so a PutBatch
-			// envelope's items are simply appended in full here too — no
-			// splitting needed to match existing behavior.
-			close(b.ch)
-			for env := range b.ch {
-				if env.items != nil {
-					b.batch = append(b.batch, env.items...)
-				} else {
-					b.batch = append(b.batch, env.item)
-				}
-				if env.sc.IsValid() {
-					batchLinks = append(batchLinks, trace.Link{SpanContext: env.sc})
-				}
-			}
-			if len(b.batch) > 0 {
-				b.cfg.logger.Infof("batcher %q: draining %d items on shutdown", b.cfg.name, len(b.batch))
-				b.dispatchAndRecord(b.batch, batchLinks, ReasonShutdown)
-			}
-			// We are the sole sender to workCh; closing here lets the
-			// persistent dispatch goroutines drain any in-flight batch and
-			// exit cleanly. No-op when SetMaxConcurrent was not configured.
-			if b.workCh != nil {
-				close(b.workCh)
-			}
+			// Shutdown: drain the channel and dispatch every remaining item,
+			// size-capped, then close the pool. See drainOnShutdown.
+			b.drainOnShutdown(batchLinks)
 			return
 
 		case env := <-b.ch:
@@ -819,44 +903,57 @@ workerLoop:
 			}
 
 			if b.drainMode.Load() { //nolint:nestif // Drain-then-fire loop with a nested non-blocking select; inherent to the drain-mode contract
-				// Drain all available items up to size cap, then fire
+				// Drain the already-queued items up to the size cap, then fire
 				// immediately. appendItems may itself flush mid-drain if a
-				// PutBatch envelope fills to size, which is fine: the outer
-				// `for len(b.batch) < b.size` condition below just keeps
-				// draining into the (now fresh) batch.
+				// PutBatch envelope fills to size.
 				items := env.items
 				if items == nil {
 					items = []*T{env.item}
 				}
-				batchLinks, _, exit = b.appendItems(items, batchLinks)
+				var dFlushed bool
+				batchLinks, dFlushed, exit = b.appendItems(items, batchLinks)
 				if exit {
+					b.drainOnShutdown(batchLinks)
 					return
 				}
 
-				for len(b.batch) < b.size {
-					select {
-					case drainEnv := <-b.ch:
-						if drainEnv.sc.IsValid() {
-							batchLinks = append(batchLinks, trace.Link{SpanContext: drainEnv.sc})
+				// Only chase more queued items if the initial envelope did not
+				// itself fill and dispatch a batch. This bounds the drain to at
+				// most one dispatched batch per outer-loop iteration, so b.done,
+				// the trigger and the timer are always serviced promptly — even
+				// under sustained load that keeps b.ch non-empty (previously the
+				// loop could spin here for seconds without returning to select).
+				if !dFlushed {
+				drainLoop:
+					for len(b.batch) < b.size {
+						select {
+						case drainEnv := <-b.ch:
+							if drainEnv.sc.IsValid() {
+								batchLinks = append(batchLinks, trace.Link{SpanContext: drainEnv.sc})
+							}
+							dItems := drainEnv.items
+							if dItems == nil {
+								dItems = []*T{drainEnv.item}
+							}
+							batchLinks, dFlushed, exit = b.appendItems(dItems, batchLinks)
+							if exit {
+								b.drainOnShutdown(batchLinks)
+								return
+							}
+							if dFlushed {
+								break drainLoop
+							}
+						default:
+							break drainLoop
 						}
-						items := drainEnv.items
-						if items == nil {
-							items = []*T{drainEnv.item}
-						}
-						batchLinks, _, exit = b.appendItems(items, batchLinks)
-						if exit {
-							return
-						}
-					default:
-						batchLinks, exit = b.flushBatch(ReasonDrain, batchLinks)
-						if exit {
-							return
-						}
-						continue workerLoop
 					}
 				}
+
+				// Fire whatever partial remains (drain mode fires immediately);
+				// a no-op if appendItems already dispatched everything.
 				batchLinks, exit = b.flushBatch(ReasonDrain, batchLinks)
 				if exit {
+					b.drainOnShutdown(batchLinks)
 					return
 				}
 				continue workerLoop
@@ -882,10 +979,11 @@ workerLoop:
 			var flushedDuringAppend bool
 			batchLinks, flushedDuringAppend, exit = b.appendItems(items, batchLinks)
 			if exit {
+				b.drainOnShutdown(batchLinks)
 				return
 			}
 
-			if b.greedyAccumulate.Load() {
+			if b.greedyAccumulate.Load() { //nolint:nestif // Greedy non-blocking drain with a mid-drain flush bound; inherent to the accumulate contract
 				// Opportunistically pull additional already-queued items into
 				// this same cycle without blocking and without firing early
 				// (unlike drain mode's `default` arm, this loop never flushes
@@ -907,7 +1005,16 @@ workerLoop:
 						batchLinks, gFlushed, exit = b.appendItems(gItems, batchLinks)
 						flushedDuringAppend = flushedDuringAppend || gFlushed
 						if exit {
+							b.drainOnShutdown(batchLinks)
 							return
+						}
+						if gFlushed {
+							// A full batch was dispatched mid-drain; this cycle
+							// is complete. Stop and return to the outer select so
+							// done/trigger/timer are serviced — greedy must not
+							// keep chasing a fresh cycle's items in one pass, which
+							// would starve the worker under sustained load.
+							break greedyDrain
 						}
 					default:
 						break greedyDrain
@@ -938,6 +1045,7 @@ workerLoop:
 			timerCh = nil
 			batchLinks, exit = b.flushBatch(ReasonTimeout, batchLinks)
 			if exit {
+				b.drainOnShutdown(batchLinks)
 				return
 			}
 
@@ -948,6 +1056,7 @@ workerLoop:
 			}
 			batchLinks, exit = b.flushBatch(ReasonTimeout, batchLinks)
 			if exit {
+				b.drainOnShutdown(batchLinks)
 				return
 			}
 
@@ -959,6 +1068,7 @@ workerLoop:
 			// Non-blocking drain: if Trigger() raced ahead of a buffered Put, pull
 			// any immediately-available items (up to the size cap) so they are
 			// included in this flush rather than stranded until the next tick.
+			var tFlushed bool
 		triggerDrain:
 			for len(b.batch) < b.size {
 				select {
@@ -976,9 +1086,17 @@ workerLoop:
 					if items == nil {
 						items = []*T{env.item}
 					}
-					batchLinks, _, exit = b.appendItems(items, batchLinks)
+					batchLinks, tFlushed, exit = b.appendItems(items, batchLinks)
 					if exit {
+						b.drainOnShutdown(batchLinks)
 						return
+					}
+					if tFlushed {
+						// A full batch was dispatched mid-drain; stop chasing new
+						// items so this Trigger cannot spin here under sustained
+						// load (mirrors the greedy/drain bound). The trailing
+						// partial is flushed below.
+						break triggerDrain
 					}
 				default:
 					break triggerDrain
@@ -986,6 +1104,7 @@ workerLoop:
 			}
 			batchLinks, exit = b.flushBatch(ReasonManual, batchLinks)
 			if exit {
+				b.drainOnShutdown(batchLinks)
 				return
 			}
 		}

--- a/batcher.go
+++ b/batcher.go
@@ -126,19 +126,20 @@ type workItem[T any] struct {
 //   - Items are passed by pointer to avoid copying
 //   - The internal worker goroutine runs indefinitely until Close() is called
 type Batcher[T any] struct {
-	fn            func([]*T)
-	size          int
-	timeout       time.Duration
-	batch         []*T
-	ch            chan itemEnvelope[T]
-	triggerCh     chan struct{}
-	background    bool
-	usePool       bool
-	pool          *sync.Pool
-	done          chan struct{}
-	drainMode     atomic.Bool
-	maxConcurrent int
-	cfg           *config
+	fn               func([]*T)
+	size             int
+	timeout          time.Duration
+	batch            []*T
+	ch               chan itemEnvelope[T]
+	triggerCh        chan struct{}
+	background       bool
+	usePool          bool
+	pool             *sync.Pool
+	done             chan struct{}
+	drainMode        atomic.Bool
+	greedyAccumulate atomic.Bool
+	maxConcurrent    int
+	cfg              *config
 	// workCh is non-nil iff SetMaxConcurrent(n>0) was called. When non-nil,
 	// the worker dispatches batches to a fixed pool of N persistent goroutines
 	// over an unbuffered (rendezvous) channel — sender blocks until a worker
@@ -217,6 +218,9 @@ func New[T any](size int, timeout time.Duration, fn func(batch []*T), background
 		finished:   make(chan struct{}),
 		cfg:        applyOptions(opts),
 	}
+	if b.cfg.greedyAccumulate {
+		b.greedyAccumulate.Store(true)
+	}
 
 	go b.worker()
 
@@ -257,6 +261,9 @@ func NewWithPool[T any](size int, timeout time.Duration, fn func(batch []*T), ba
 		done:     make(chan struct{}),
 		finished: make(chan struct{}),
 		cfg:      applyOptions(opts),
+	}
+	if b.cfg.greedyAccumulate {
+		b.greedyAccumulate.Store(true)
 	}
 
 	go b.worker()
@@ -448,7 +455,37 @@ func (b *Batcher[T]) SetDrainMode(enabled bool) {
 		b.cfg.logger.Warnf("batcher %q: SetDrainMode(true) rejected — tick mode is enabled", b.cfg.name)
 		return
 	}
+	if enabled && b.greedyAccumulate.Load() {
+		b.cfg.logger.Warnf("batcher %q: SetDrainMode(true) rejected — greedy accumulate is enabled", b.cfg.name)
+		return
+	}
 	b.drainMode.Store(enabled)
+}
+
+// SetGreedyAccumulate enables or disables greedy accumulate mode.
+//
+// When enabled, after receiving an item the worker opportunistically drains
+// any additional items already waiting on the channel (up to the size cap)
+// into the SAME batch before re-entering select — trading a per-item 5-arm
+// select for a cheap non-blocking 2-arm receive for every item after the
+// first in a burst. Unlike drain mode, greedy accumulate never fires a
+// batch early: it only changes how quickly items already queued are pulled
+// off the channel between the existing size/timeout/trigger flush points.
+// A batch under greedy accumulate is never smaller than the same arrival
+// pattern would produce without it.
+//
+// Mutually exclusive with drain mode (which does fire early): enabling
+// either while the other is on logs a warning and is a no-op, matching
+// SetDrainMode's existing exclusion with tick mode. Safe to call at
+// construction via WithGreedyAccumulate or afterward via this method,
+// though changing it once items are already flowing does not retroactively
+// affect an in-progress accumulation cycle.
+func (b *Batcher[T]) SetGreedyAccumulate(enabled bool) {
+	if enabled && b.drainMode.Load() {
+		b.cfg.logger.Warnf("batcher %q: SetGreedyAccumulate(true) rejected — drain mode is enabled", b.cfg.name)
+		return
+	}
+	b.greedyAccumulate.Store(enabled)
 }
 
 // SetMaxConcurrent limits the number of concurrent in-flight background batch
@@ -846,6 +883,36 @@ workerLoop:
 			batchLinks, flushedDuringAppend, exit = b.appendItems(items, batchLinks)
 			if exit {
 				return
+			}
+
+			if b.greedyAccumulate.Load() {
+				// Opportunistically pull additional already-queued items into
+				// this same cycle without blocking and without firing early
+				// (unlike drain mode's `default` arm, this loop never flushes
+				// on an empty channel — it only stops trying). Each pulled
+				// envelope still goes through appendItems, so oversized
+				// PutBatch groups keep splitting at the cap exactly as above.
+			greedyDrain:
+				for len(b.batch) < b.size {
+					select {
+					case greedyEnv := <-b.ch:
+						if greedyEnv.sc.IsValid() {
+							batchLinks = append(batchLinks, trace.Link{SpanContext: greedyEnv.sc})
+						}
+						gItems := greedyEnv.items
+						if gItems == nil {
+							gItems = []*T{greedyEnv.item}
+						}
+						var gFlushed bool
+						batchLinks, gFlushed, exit = b.appendItems(gItems, batchLinks)
+						flushedDuringAppend = flushedDuringAppend || gFlushed
+						if exit {
+							return
+						}
+					default:
+						break greedyDrain
+					}
+				}
 			}
 
 			switch {

--- a/batcher.go
+++ b/batcher.go
@@ -730,17 +730,24 @@ func (b *Batcher[T]) flushBatch(reason string, batchLinks []trace.Link) (newBatc
 // "was empty on entry" test alone is not sufficient once a mid-call flush
 // can happen. See the worker() call site.
 //
+// reason is the trigger reason recorded on each internal (mid-split) flush, so
+// the caller's cycle semantics are preserved: the normal accumulation and
+// greedy paths pass ReasonSize (these splits fire because the batch reached the
+// cap), while the drain and trigger paths pass ReasonDrain / ReasonManual so a
+// PutBatch group split during those cycles is labeled by the cycle that drove
+// it rather than always as "size".
+//
 // If flushBatch reports exit=true (shutdown raced a full worker pool), this
 // stops immediately and propagates it — mirroring the original single-item
 // saveBatch behavior of returning from worker() at that point.
-func (b *Batcher[T]) appendItems(items []*T, batchLinks []trace.Link) (newBatchLinks []trace.Link, flushed bool, exit bool) { //nolint:gocognit // Split-at-cap loop with an early-exit propagation path; each branch is a single guarded step
+func (b *Batcher[T]) appendItems(items []*T, batchLinks []trace.Link, reason string) (newBatchLinks []trace.Link, flushed bool, exit bool) { //nolint:gocognit // Split-at-cap loop with an early-exit propagation path; each branch is a single guarded step
 	for len(items) > 0 {
 		room := b.size - len(b.batch)
 		if room <= 0 {
 			// Defensive: b.batch should never already be at/over size here
 			// (the loop below always flushes the instant it reaches size),
 			// but guard against stalling if that invariant is ever violated.
-			batchLinks, exit = b.flushBatch(ReasonSize, batchLinks)
+			batchLinks, exit = b.flushBatch(reason, batchLinks)
 			flushed = true
 			if exit {
 				// flushBatch cleared b.batch on the shutdown-race path; keep the
@@ -761,7 +768,7 @@ func (b *Batcher[T]) appendItems(items []*T, batchLinks []trace.Link) (newBatchL
 		items = items[n:]
 
 		if len(b.batch) == b.size {
-			batchLinks, exit = b.flushBatch(ReasonSize, batchLinks)
+			batchLinks, exit = b.flushBatch(reason, batchLinks)
 			flushed = true
 			if exit {
 				b.batch = append(b.batch, items...)
@@ -924,7 +931,7 @@ workerLoop:
 					items = []*T{env.item}
 				}
 				var dFlushed bool
-				batchLinks, dFlushed, exit = b.appendItems(items, batchLinks)
+				batchLinks, dFlushed, exit = b.appendItems(items, batchLinks, ReasonDrain)
 				if exit {
 					b.drainOnShutdown(batchLinks)
 					return
@@ -948,7 +955,7 @@ workerLoop:
 							if dItems == nil {
 								dItems = []*T{drainEnv.item}
 							}
-							batchLinks, dFlushed, exit = b.appendItems(dItems, batchLinks)
+							batchLinks, dFlushed, exit = b.appendItems(dItems, batchLinks, ReasonDrain)
 							if exit {
 								b.drainOnShutdown(batchLinks)
 								return
@@ -990,7 +997,7 @@ workerLoop:
 			}
 
 			var flushedDuringAppend bool
-			batchLinks, flushedDuringAppend, exit = b.appendItems(items, batchLinks)
+			batchLinks, flushedDuringAppend, exit = b.appendItems(items, batchLinks, ReasonSize)
 			if exit {
 				b.drainOnShutdown(batchLinks)
 				return
@@ -1015,7 +1022,7 @@ workerLoop:
 							gItems = []*T{greedyEnv.item}
 						}
 						var gFlushed bool
-						batchLinks, gFlushed, exit = b.appendItems(gItems, batchLinks)
+						batchLinks, gFlushed, exit = b.appendItems(gItems, batchLinks, ReasonSize)
 						flushedDuringAppend = flushedDuringAppend || gFlushed
 						if exit {
 							b.drainOnShutdown(batchLinks)
@@ -1099,7 +1106,7 @@ workerLoop:
 					if items == nil {
 						items = []*T{env.item}
 					}
-					batchLinks, tFlushed, exit = b.appendItems(items, batchLinks)
+					batchLinks, tFlushed, exit = b.appendItems(items, batchLinks, ReasonManual)
 					if exit {
 						b.drainOnShutdown(batchLinks)
 						return

--- a/batcher.go
+++ b/batcher.go
@@ -79,9 +79,14 @@ var errBatchPanic = errors.New("batcher: panic in batch fn")
 // captured at PutCtx time. The SpanContext is a 24-byte value type, so the
 // envelope adds bounded memory overhead per channel slot. An invalid (zero)
 // SpanContext means no span link will be emitted for this item.
+//
+// items is non-nil for envelopes enqueued via PutBatch/PutBatchCtx and holds
+// the whole group; item is unused in that case. Exactly one of item/items is
+// populated per envelope.
 type itemEnvelope[T any] struct {
-	item *T
-	sc   trace.SpanContext
+	item  *T
+	items []*T
+	sc    trace.SpanContext
 }
 
 // workItem is the payload handed from the worker goroutine to the persistent
@@ -304,9 +309,54 @@ func (b *Batcher[T]) PutCtx(ctx context.Context, item *T, _ ...int) {
 	})
 }
 
-// enqueue is the shared hot path for Put and PutCtx. It tries a non-blocking
-// channel send first and only times the blocking fallback when the buffer is
-// full so the common case is allocation- and timer-free.
+// PutBatch adds a group of items to the batcher in a single channel send,
+// instead of one send per item. This is the multi-item counterpart to Put:
+// use it when a caller already has N items ready together (e.g. all inputs
+// of one transaction) to cut the per-item channel-lock and collector-select
+// overhead down to a single operation for the whole group.
+//
+// The group is treated as an ordered unit by the collector: if it is smaller
+// than the configured batch size it simply accumulates like N individual
+// Put calls; if appending it would exceed the size cap, the collector splits
+// it into full-size batches (each dispatched immediately, in order) plus at
+// most one trailing partial batch that continues accumulating normally.
+// Batch size is always honored — a PutBatch call never produces a batch
+// larger than the batcher's configured size, even when len(items) > size.
+//
+// Use PutBatchCtx instead if you have an active OpenTelemetry span context
+// you want linked to the eventual batch span(s). Passing a nil or empty
+// slice is a no-op.
+//
+// Parameters:
+//   - items: The group of items to enqueue together. Must not contain nil pointers.
+//   - _: Variadic int parameter for payload size (ignored, kept for API compatibility)
+func (b *Batcher[T]) PutBatch(items []*T, _ ...int) {
+	if len(items) == 0 {
+		return
+	}
+	b.enqueue(itemEnvelope[T]{items: items})
+}
+
+// PutBatchCtx is like PutBatch but captures the SpanContext from ctx so the
+// batch span(s) produced from this group carry it as a link. When a group
+// larger than the batch size is split into multiple dispatched batches (see
+// PutBatch), only the first resulting batch carries the link — see the
+// package-level notes on split batches. If ctx has no active span the call
+// behaves identically to PutBatch.
+func (b *Batcher[T]) PutBatchCtx(ctx context.Context, items []*T, _ ...int) {
+	if len(items) == 0 {
+		return
+	}
+	b.enqueue(itemEnvelope[T]{
+		items: items,
+		sc:    trace.SpanContextFromContext(ctx),
+	})
+}
+
+// enqueue is the shared hot path for Put/PutCtx/PutBatch/PutBatchCtx. It
+// tries a non-blocking channel send first and only times the blocking
+// fallback when the buffer is full so the common case is allocation- and
+// timer-free.
 func (b *Batcher[T]) enqueue(env itemEnvelope[T]) {
 	b.cfg.metricsBound.Enqueued()
 	select {
@@ -471,6 +521,160 @@ func (b *Batcher[T]) SetTickInterval(d time.Duration) {
 	b.cfg.logger.Infof("batcher %q: tick mode enabled, interval=%s", b.cfg.name, d)
 }
 
+// flushBatch dispatches the current batch (if non-empty) via fn — following
+// the background/pool/workCh dispatch rules the Batcher was configured with
+// — and resets b.batch (and returns a fresh nil batchLinks) for the next
+// accumulation cycle.
+//
+// This is the batch-dispatch step formerly inlined at the worker's
+// goto-target "saveBatch" label. It is factored into a callable method so a
+// single b.ch receive carrying multiple items (PutBatch/PutBatchCtx) can
+// flush more than once — at each size-cap boundary — without leaving the
+// select statement between flushes (see appendItems).
+//
+// Returns exit=true in the one case that mirrors the original inline
+// behavior of returning from worker() directly: shutdown (b.done closing)
+// raced ahead of a free slot in the SetMaxConcurrent worker pool. The batch
+// is still dispatched synchronously in that case; exit simply tells the
+// caller (worker's select-loop body) to stop processing and let worker()
+// return, exactly as the original `return` statement did at that call site.
+func (b *Batcher[T]) flushBatch(reason string, batchLinks []trace.Link) (newBatchLinks []trace.Link, exit bool) { //nolint:gocognit,gocyclo // Extracted verbatim from worker()'s former saveBatch label; the branching (background/pool/workCh/shutdown-race) is inherent to the dispatch contract, not incidental
+	if len(b.batch) == 0 {
+		return batchLinks, false
+	}
+
+	batch := b.batch
+	links := batchLinks
+
+	if b.background { //nolint:nestif // Necessary complexity for handling pooling and background modes
+		// Track this dispatch so the shutdown drain (inflight.Wait in worker)
+		// blocks until fn has actually run. Add is always on the worker
+		// goroutine, so it never races the Wait that also runs there; Done is
+		// paired below (persistent worker, fresh goroutine, or the inline
+		// shutdown path).
+		b.inflight.Add(1)
+
+		if b.workCh != nil {
+			// Hand the batch to a persistent worker. The unbuffered channel
+			// blocks here when all N workers are busy, applying backpressure
+			// up through b.ch and Put()/PutBatch().
+			semStart := time.Now()
+			select {
+			case b.workCh <- workItem[T]{batch: batch, links: links, reason: reason}:
+				if wait := time.Since(semStart); wait > time.Microsecond {
+					b.cfg.metricsBound.BackpressureWait(wait)
+				}
+				// persistent worker calls inflight.Done after dispatch
+			case <-b.done:
+				// Shutdown while waiting for a worker — process synchronously,
+				// then signal the caller to stop (mirrors the original inline
+				// `return` from worker() at this exact point).
+				b.cfg.logger.Warnf("batcher %q: dispatching batch of %d items inline due to shutdown while waiting for worker slot", b.cfg.name, len(batch))
+				b.dispatchAndRecord(batch, links, reason)
+				if b.usePool {
+					slice := batch[:0]
+					b.pool.Put(&slice)
+				}
+				b.inflight.Done()
+				return nil, true
+			}
+		} else if b.usePool {
+			// Unbounded concurrency path: spawn a fresh goroutine per batch.
+			go func(batch []*T, links []trace.Link, reason string) {
+				defer b.inflight.Done()
+				b.dispatchAndRecord(batch, links, reason)
+				slice := batch[:0]
+				b.pool.Put(&slice)
+			}(batch, links, reason)
+		} else {
+			go func(batch []*T, links []trace.Link, reason string) {
+				defer b.inflight.Done()
+				b.dispatchAndRecord(batch, links, reason)
+			}(batch, links, reason)
+		}
+	} else {
+		b.dispatchAndRecord(batch, links, reason)
+		if b.usePool {
+			slice := batch[:0]
+			b.pool.Put(&slice)
+		}
+	}
+
+	// Reset for the next batch. We must not reuse the underlying arrays of
+	// `batch` / `links` because background dispatch may still be reading
+	// them — allocate fresh slices instead. The pool path takes care of
+	// `batch` separately.
+	if b.usePool {
+		newBatchPtr := b.pool.Get().(*[]*T)
+		b.batch = *newBatchPtr
+	} else {
+		b.batch = make([]*T, 0, b.size)
+	}
+
+	return nil, false
+}
+
+// appendItems appends items to the current batch, splitting into full
+// dispatches of exactly b.size whenever a single PutBatch/PutBatchCtx
+// envelope contains more items than currently fit. Each full split is
+// flushed immediately via flushBatch, so a batch handed to fn is never
+// larger than the configured size — even when a caller enqueues an
+// over-sized group in one call. At most one trailing partial batch remains
+// in b.batch, accumulating normally toward the next size/timeout/trigger
+// flush.
+//
+// batchLinks is expected to already include this envelope's span link (if
+// any) before this call: the link is not duplicated across split boundaries,
+// so it travels with whichever batch happens to be open when this call
+// begins — either the first full split produced here, or the trailing
+// partial batch if no split was needed.
+//
+// flushed reports whether at least one internal flush happened. Callers that
+// manage the lazy timeout timer need this: if a flush occurred, any items
+// left in b.batch afterward began a brand-new accumulation cycle *during*
+// this call (not before it), so the timer must be (re-)armed for them even
+// though b.batch was already non-empty when appendItems was called — the
+// "was empty on entry" test alone is not sufficient once a mid-call flush
+// can happen. See the worker() call site.
+//
+// If flushBatch reports exit=true (shutdown raced a full worker pool), this
+// stops immediately and propagates it — mirroring the original single-item
+// saveBatch behavior of returning from worker() at that point.
+func (b *Batcher[T]) appendItems(items []*T, batchLinks []trace.Link) (newBatchLinks []trace.Link, flushed bool, exit bool) { //nolint:gocognit // Split-at-cap loop with an early-exit propagation path; each branch is a single guarded step
+	for len(items) > 0 {
+		room := b.size - len(b.batch)
+		if room <= 0 {
+			// Defensive: b.batch should never already be at/over size here
+			// (the loop below always flushes the instant it reaches size),
+			// but guard against stalling if that invariant is ever violated.
+			batchLinks, exit = b.flushBatch(ReasonSize, batchLinks)
+			flushed = true
+			if exit {
+				return batchLinks, flushed, true
+			}
+			room = b.size
+		}
+
+		n := len(items)
+		if n > room {
+			n = room
+		}
+
+		b.batch = append(b.batch, items[:n]...)
+		items = items[n:]
+
+		if len(b.batch) == b.size {
+			batchLinks, exit = b.flushBatch(ReasonSize, batchLinks)
+			flushed = true
+			if exit {
+				return batchLinks, flushed, true
+			}
+		}
+	}
+
+	return batchLinks, flushed, false
+}
+
 // worker is the core processing loop that manages batch aggregation and processing.
 //
 // This function runs as a background goroutine and continuously monitors three conditions
@@ -494,16 +698,18 @@ func (b *Batcher[T]) SetTickInterval(d time.Duration) {
 //   - Uses slice pooling if enabled to reduce allocations
 //
 // Notes:
-//   - Uses goto for performance optimization to avoid deep nesting
-//   - Empty batches are not processed (checked before invoking fn)
+//   - Empty batches are not processed (checked inside flushBatch)
 //   - Reuses timers to reduce allocations and GC pressure
 //   - When usePool=true, manages slice lifecycle through sync.Pool for memory efficiency
 //   - Each batch dispatch is wrapped in defer/recover so a panic from the user fn is
 //     logged, recorded as a metric and span error, and the worker keeps running
+//   - A single b.ch receive can carry more than one item (PutBatch/PutBatchCtx);
+//     appendItems splits it across as many flushBatch calls as needed
 func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function handles multiple channels and conditions
 	var timer *time.Timer
 	var timerCh <-chan time.Time // nil channel blocks forever, enabling lazy timer activation
 	var batchLinks []trace.Link
+	var exit bool
 
 	// Registered first so they run last (LIFO): on any worker return, first
 	// wait for outstanding background dispatches to finish (inflight), then
@@ -527,15 +733,23 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 	// previous localTickerCh snapshot approach while dropping the boolean flag.
 	var tickerCh <-chan time.Time
 
+workerLoop:
 	for {
-		var reason string
-
 		select {
 		case <-b.done:
-			// Shutdown: drain channel and process remaining items.
+			// Shutdown: drain channel and process remaining items. This
+			// residual dispatch already ignores the size cap for ordinary
+			// single-item accumulation (it flushes whatever piled up between
+			// the done-signal and the channel fully draining), so a PutBatch
+			// envelope's items are simply appended in full here too — no
+			// splitting needed to match existing behavior.
 			close(b.ch)
 			for env := range b.ch {
-				b.batch = append(b.batch, env.item)
+				if env.items != nil {
+					b.batch = append(b.batch, env.items...)
+				} else {
+					b.batch = append(b.batch, env.item)
+				}
 				if env.sc.IsValid() {
 					batchLinks = append(batchLinks, trace.Link{SpanContext: env.sc})
 				}
@@ -553,7 +767,6 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 			return
 
 		case env := <-b.ch:
-			b.batch = append(b.batch, env.item)
 			if env.sc.IsValid() {
 				batchLinks = append(batchLinks, trace.Link{SpanContext: env.sc})
 			}
@@ -568,30 +781,84 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 				}
 			}
 
-			if b.drainMode.Load() {
-				// Drain all available items up to size cap, then fire immediately.
+			if b.drainMode.Load() { //nolint:nestif // Drain-then-fire loop with a nested non-blocking select; inherent to the drain-mode contract
+				// Drain all available items up to size cap, then fire
+				// immediately. appendItems may itself flush mid-drain if a
+				// PutBatch envelope fills to size, which is fine: the outer
+				// `for len(b.batch) < b.size` condition below just keeps
+				// draining into the (now fresh) batch.
+				items := env.items
+				if items == nil {
+					items = []*T{env.item}
+				}
+				batchLinks, _, exit = b.appendItems(items, batchLinks)
+				if exit {
+					return
+				}
+
 				for len(b.batch) < b.size {
 					select {
-					case env := <-b.ch:
-						b.batch = append(b.batch, env.item)
-						if env.sc.IsValid() {
-							batchLinks = append(batchLinks, trace.Link{SpanContext: env.sc})
+					case drainEnv := <-b.ch:
+						if drainEnv.sc.IsValid() {
+							batchLinks = append(batchLinks, trace.Link{SpanContext: drainEnv.sc})
+						}
+						items := drainEnv.items
+						if items == nil {
+							items = []*T{drainEnv.item}
+						}
+						batchLinks, _, exit = b.appendItems(items, batchLinks)
+						if exit {
+							return
 						}
 					default:
-						reason = ReasonDrain
-						goto saveBatch
+						batchLinks, exit = b.flushBatch(ReasonDrain, batchLinks)
+						if exit {
+							return
+						}
+						continue workerLoop
 					}
 				}
-				reason = ReasonDrain
-				goto saveBatch
+				batchLinks, exit = b.flushBatch(ReasonDrain, batchLinks)
+				if exit {
+					return
+				}
+				continue workerLoop
 			}
 
-			// Lazy timer activation: start on first item only. Reuse the same
-			// Timer across batches to avoid a per-batch allocation; safe under
-			// Go 1.23+ semantics where Reset on a stopped/expired timer will
-			// not deliver a stale value. Skipped when tick mode is wired —
-			// the tickerCh arm below drives all time-based flushes.
-			if len(b.batch) == 1 && tickerCh == nil {
+			// Lazy timer activation: (re-)start whenever a fresh accumulation
+			// cycle begins — either because the batch was empty when this
+			// envelope arrived, or because appendItems flushed a full batch
+			// partway through an over-sized PutBatch and left a trailing
+			// partial batch that just started accumulating *during* this
+			// call. Reuse the same Timer across batches to avoid a per-batch
+			// allocation; safe under Go 1.23+ semantics where Reset on a
+			// stopped/expired timer will not deliver a stale value. Skipped
+			// when tick mode is wired — the tickerCh arm below drives all
+			// time-based flushes.
+			batchWasEmpty := len(b.batch) == 0
+
+			items := env.items
+			if items == nil {
+				items = []*T{env.item}
+			}
+
+			var flushedDuringAppend bool
+			batchLinks, flushedDuringAppend, exit = b.appendItems(items, batchLinks)
+			if exit {
+				return
+			}
+
+			switch {
+			case len(b.batch) == 0:
+				// Fully flushed (single item, or an exact-multiple PutBatch)
+				// — nothing left accumulating, so any timer no longer applies.
+				if timer != nil {
+					timer.Stop()
+					timerCh = nil
+				}
+			case tickerCh == nil && (batchWasEmpty || flushedDuringAppend):
+				// A fresh cycle is accumulating as of right now: either this
+				// envelope started it from empty, or a mid-call flush did.
 				if timer == nil {
 					timer = time.NewTimer(b.timeout)
 				} else {
@@ -600,27 +867,22 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 				timerCh = timer.C
 			}
 
-			if len(b.batch) == b.size {
-				if timer != nil {
-					timer.Stop()
-					timerCh = nil
-				}
-				reason = ReasonSize
-				goto saveBatch
-			}
-
 		case <-timerCh: // Only fires when timerCh != nil (batch has items).
 			timerCh = nil
-			reason = ReasonTimeout
-			goto saveBatch
+			batchLinks, exit = b.flushBatch(ReasonTimeout, batchLinks)
+			if exit {
+				return
+			}
 
 		case <-tickerCh: // nil channel blocks forever when tick mode disabled.
 			if len(b.batch) == 0 {
 				// Skip empty tick — no fn call, no span, no metric.
 				continue
 			}
-			reason = ReasonTimeout
-			goto saveBatch
+			batchLinks, exit = b.flushBatch(ReasonTimeout, batchLinks)
+			if exit {
+				return
+			}
 
 		case <-b.triggerCh:
 			if timer != nil {
@@ -630,10 +892,10 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 			// Non-blocking drain: if Trigger() raced ahead of a buffered Put, pull
 			// any immediately-available items (up to the size cap) so they are
 			// included in this flush rather than stranded until the next tick.
+		triggerDrain:
 			for len(b.batch) < b.size {
 				select {
 				case env := <-b.ch:
-					b.batch = append(b.batch, env.item)
 					if env.sc.IsValid() {
 						batchLinks = append(batchLinks, trace.Link{SpanContext: env.sc})
 					}
@@ -643,85 +905,22 @@ func (b *Batcher[T]) worker() { //nolint:gocognit,gocyclo // Worker function han
 							tickerCh = t.C
 						}
 					}
-				default:
-					goto afterDrain
-				}
-			}
-		afterDrain:
-			reason = ReasonManual
-			goto saveBatch
-		}
-
-		continue
-
-	saveBatch:
-		if len(b.batch) > 0 { //nolint:nestif // Necessary complexity for handling pooling and background modes
-			batch := b.batch
-			links := batchLinks
-
-			if b.background {
-				// Track this dispatch so the shutdown drain (inflight.Wait in
-				// worker) blocks until fn has actually run. Add is always on the
-				// worker goroutine, so it never races the Wait that also runs
-				// there; Done is paired below (persistent worker, fresh
-				// goroutine, or the inline shutdown path).
-				b.inflight.Add(1)
-
-				if b.workCh != nil {
-					// Hand the batch to a persistent worker. The unbuffered
-					// channel blocks here when all N workers are busy,
-					// applying backpressure up through b.ch and Put().
-					semStart := time.Now()
-					select {
-					case b.workCh <- workItem[T]{batch: batch, links: links, reason: reason}:
-						if wait := time.Since(semStart); wait > time.Microsecond {
-							b.cfg.metricsBound.BackpressureWait(wait)
-						}
-						// persistent worker calls inflight.Done after dispatch
-					case <-b.done:
-						// Shutdown while waiting for a worker — process synchronously.
-						b.cfg.logger.Warnf("batcher %q: dispatching batch of %d items inline due to shutdown while waiting for worker slot", b.cfg.name, len(batch))
-						b.dispatchAndRecord(batch, links, reason)
-						if b.usePool {
-							slice := batch[:0]
-							b.pool.Put(&slice)
-						}
-						b.inflight.Done()
+					items := env.items
+					if items == nil {
+						items = []*T{env.item}
+					}
+					batchLinks, _, exit = b.appendItems(items, batchLinks)
+					if exit {
 						return
 					}
-				} else if b.usePool {
-					// Unbounded concurrency path: spawn a fresh goroutine per batch.
-					go func(batch []*T, links []trace.Link, reason string) {
-						defer b.inflight.Done()
-						b.dispatchAndRecord(batch, links, reason)
-						slice := batch[:0]
-						b.pool.Put(&slice)
-					}(batch, links, reason)
-				} else {
-					go func(batch []*T, links []trace.Link, reason string) {
-						defer b.inflight.Done()
-						b.dispatchAndRecord(batch, links, reason)
-					}(batch, links, reason)
-				}
-			} else {
-				b.dispatchAndRecord(batch, links, reason)
-				if b.usePool {
-					slice := batch[:0]
-					b.pool.Put(&slice)
+				default:
+					break triggerDrain
 				}
 			}
-
-			// Reset for the next batch. We must not reuse the underlying
-			// arrays of `batch` / `links` because background dispatch may
-			// still be reading them — allocate fresh slices instead. The
-			// pool path takes care of `batch` separately.
-			if b.usePool {
-				newBatchPtr := b.pool.Get().(*[]*T)
-				b.batch = *newBatchPtr
-			} else {
-				b.batch = make([]*T, 0, b.size)
+			batchLinks, exit = b.flushBatch(ReasonManual, batchLinks)
+			if exit {
+				return
 			}
-			batchLinks = nil
 		}
 	}
 }

--- a/batcher_greedy_accumulate_benchmark_test.go
+++ b/batcher_greedy_accumulate_benchmark_test.go
@@ -1,0 +1,37 @@
+package batcher
+
+import (
+	"testing"
+	"time"
+)
+
+// BenchmarkPut_NonGreedy and BenchmarkPut_Greedy measure per-item CPU cost
+// under sustained load (channel kept saturated by the benchmark loop, which
+// approximates the bursty-arrival case greedy accumulate targets: every item
+// after the first in a burst costs a non-blocking 2-arm receive instead of a
+// 5-arm select).
+func BenchmarkPut_NonGreedy(b *testing.B) {
+	benchmarkPutThroughput(b, false)
+}
+
+func BenchmarkPut_Greedy(b *testing.B) {
+	benchmarkPutThroughput(b, true)
+}
+
+func benchmarkPutThroughput(b *testing.B, greedy bool) {
+	const batchSize = 256
+
+	var opts []Option
+	if greedy {
+		opts = append(opts, WithGreedyAccumulate(true))
+	}
+
+	bt := New[int](batchSize, time.Hour, func(_ []*int) {}, true, opts...)
+	defer bt.Close()
+
+	v := 0
+
+	for b.Loop() {
+		bt.Put(&v)
+	}
+}

--- a/batcher_greedy_accumulate_test.go
+++ b/batcher_greedy_accumulate_test.go
@@ -1,0 +1,200 @@
+package batcher
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestGreedyAccumulate_NeverProducesSmallerBatchesThanNonGreedy verifies the
+// core §6.2 design guarantee: greedy accumulate changes only how quickly
+// items are pulled off the channel between size/timeout/trigger checks — it
+// never changes flush triggers or produces a batch smaller than the
+// non-greedy path would for the same arrival pattern. Here that means: when
+// enough items are queued up-front to fill several batches, greedy
+// accumulate still fills every batch to exactly the configured size (it does
+// not fire early on a momentarily-empty channel the way drain mode does).
+func TestGreedyAccumulate_NeverProducesSmallerBatchesThanNonGreedy(t *testing.T) {
+	const size = 10
+	const totalItems = 35 // 3 full batches + a trailing partial of 5
+
+	var mu sync.Mutex
+	var batchSizes []int
+	flushed := make(chan struct{}, totalItems)
+
+	b := New[int](size, time.Hour, func(batch []*int) {
+		mu.Lock()
+		batchSizes = append(batchSizes, len(batch))
+		mu.Unlock()
+		flushed <- struct{}{}
+	}, false, WithGreedyAccumulate(true))
+	defer b.Close()
+
+	for i := 0; i < totalItems; i++ {
+		v := i
+		b.Put(&v)
+	}
+
+	for i := 0; i < 3; i++ {
+		select {
+		case <-flushed:
+		case <-time.After(time.Second):
+			t.Fatalf("expected full-size flush #%d under greedy accumulate", i+1)
+		}
+	}
+
+	// Trailing 5 items should not flush yet (under size, no timeout/trigger).
+	select {
+	case <-flushed:
+		t.Fatal("trailing partial batch flushed before size/timeout/trigger")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	b.Trigger()
+	select {
+	case <-flushed:
+	case <-time.After(time.Second):
+		t.Fatal("expected trailing partial batch to flush on Trigger")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, []int{size, size, size, totalItems - 3*size}, batchSizes)
+}
+
+// TestGreedyAccumulate_TimerStillFires verifies that greedy accumulate does
+// not interfere with the timeout-based flush for a batch that never reaches
+// the size cap.
+func TestGreedyAccumulate_TimerStillFires(t *testing.T) {
+	done := make(chan []*int, 1)
+	b := New[int](100, 20*time.Millisecond, func(batch []*int) {
+		cp := make([]*int, len(batch))
+		copy(cp, batch)
+		done <- cp
+	}, false, WithGreedyAccumulate(true))
+	defer b.Close()
+
+	for i := 0; i < 3; i++ {
+		v := i
+		b.Put(&v)
+	}
+
+	select {
+	case batch := <-done:
+		require.Len(t, batch, 3)
+	case <-time.After(time.Second):
+		t.Fatal("expected timeout-triggered flush under greedy accumulate")
+	}
+}
+
+// TestGreedyAccumulate_RejectedWhenDrainModeEnabled verifies the two modes
+// are mutually exclusive: enabling greedy accumulate is a no-op (with a
+// logged warning) when drain mode is already on.
+func TestGreedyAccumulate_RejectedWhenDrainModeEnabled(t *testing.T) {
+	var warnings atomic.Int64
+	logger := &countingLogger{warnCount: &warnings}
+
+	b := New[int](10, time.Hour, func(_ []*int) {}, false, WithLogger(logger))
+	defer b.Close()
+
+	b.SetDrainMode(true)
+	b.SetGreedyAccumulate(true)
+
+	require.Equal(t, int64(1), warnings.Load(), "expected a warning when enabling greedy accumulate with drain mode on")
+}
+
+// TestGreedyAccumulate_DrainModeRejectedWhenGreedyEnabled verifies the
+// reverse: enabling drain mode after greedy accumulate is already on is
+// rejected with a warning, mirroring SetTickInterval/SetDrainMode's existing
+// mutual-exclusion behavior.
+func TestGreedyAccumulate_DrainModeRejectedWhenGreedyEnabled(t *testing.T) {
+	var warnings atomic.Int64
+	logger := &countingLogger{warnCount: &warnings}
+
+	b := New[int](10, time.Hour, func(_ []*int) {}, false, WithLogger(logger))
+	defer b.Close()
+
+	b.SetGreedyAccumulate(true)
+	b.SetDrainMode(true)
+
+	require.Equal(t, int64(1), warnings.Load(), "expected a warning when enabling drain mode with greedy accumulate on")
+}
+
+// TestGreedyAccumulate_WithPutBatch verifies greedy accumulate composes with
+// PutBatch: items delivered via a single multi-item envelope are eligible
+// for the same greedy non-blocking drain as individually-Put items.
+func TestGreedyAccumulate_WithPutBatch(t *testing.T) {
+	const size = 5
+	var flushCount atomic.Int64
+	done := make(chan struct{})
+
+	b := New[int](size, time.Hour, func(_ []*int) {
+		if flushCount.Add(1) == 2 {
+			close(done)
+		}
+	}, true, WithGreedyAccumulate(true))
+	defer b.Close()
+
+	items := make([]*int, 10)
+	for i := range items {
+		v := i
+		items[i] = &v
+	}
+	b.PutBatch(items)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected 2 full-size flushes from a 10-item PutBatch under greedy accumulate")
+	}
+}
+
+// TestGreedyAccumulate_AllItemsDelivered is a broader soak-style check that
+// no items are lost or duplicated when many Put calls race against greedy
+// accumulate's inner drain loop.
+func TestGreedyAccumulate_AllItemsDelivered(t *testing.T) {
+	const totalItems = 5000
+	const size = 64
+
+	var seen sync.Map
+	var count atomic.Int64
+	allDone := make(chan struct{})
+
+	b := New[int](size, 50*time.Millisecond, func(batch []*int) {
+		for _, v := range batch {
+			_, dup := seen.LoadOrStore(*v, true)
+			require.False(t, dup, "item %d observed more than once", *v)
+		}
+		if count.Add(int64(len(batch))) == totalItems {
+			close(allDone)
+		}
+	}, true, WithGreedyAccumulate(true))
+	defer b.Close()
+
+	for i := 0; i < totalItems; i++ {
+		v := i
+		b.Put(&v)
+	}
+
+	select {
+	case <-allDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("expected all %d items delivered, got %d", totalItems, count.Load())
+	}
+}
+
+// countingLogger is a minimal Logger that counts Warnf calls, used to assert
+// on the mutual-exclusion warning path without depending on log output format.
+type countingLogger struct {
+	warnCount *atomic.Int64
+}
+
+func (countingLogger) Debugf(string, ...any) {}
+func (countingLogger) Infof(string, ...any)  {}
+func (l countingLogger) Warnf(string, ...any) {
+	l.warnCount.Add(1)
+}
+func (countingLogger) Errorf(string, ...any) {}

--- a/batcher_greedy_accumulate_test.go
+++ b/batcher_greedy_accumulate_test.go
@@ -104,6 +104,11 @@ func TestGreedyAccumulate_RejectedWhenDrainModeEnabled(t *testing.T) {
 	b.SetGreedyAccumulate(true)
 
 	require.Equal(t, int64(1), warnings.Load(), "expected a warning when enabling greedy accumulate with drain mode on")
+	// The warning alone is not enough — assert the rejected mode actually
+	// stayed off (a dropped `return` in the guard would still warn but leave
+	// both modes enabled, which this catches).
+	require.True(t, b.drainMode.Load(), "drain mode must remain enabled")
+	require.False(t, b.greedyAccumulate.Load(), "greedy accumulate must not have been enabled")
 }
 
 // TestGreedyAccumulate_DrainModeRejectedWhenGreedyEnabled verifies the
@@ -121,6 +126,22 @@ func TestGreedyAccumulate_DrainModeRejectedWhenGreedyEnabled(t *testing.T) {
 	b.SetDrainMode(true)
 
 	require.Equal(t, int64(1), warnings.Load(), "expected a warning when enabling drain mode with greedy accumulate on")
+	require.True(t, b.greedyAccumulate.Load(), "greedy accumulate must remain enabled")
+	require.False(t, b.drainMode.Load(), "drain mode must not have been enabled")
+
+	// Behavioral confirmation that drain mode is truly off: a sub-size Put must
+	// NOT fire immediately (drain would; greedy never fires early).
+	fired := make(chan struct{}, 1)
+	b2 := New[int](10, time.Hour, func(_ []*int) { fired <- struct{}{} }, false, WithGreedyAccumulate(true))
+	defer b2.Close()
+	b2.SetDrainMode(true) // rejected — greedy already on
+	v := 1
+	b2.Put(&v)
+	select {
+	case <-fired:
+		t.Fatal("a sub-size Put fired immediately — drain mode was wrongly enabled")
+	case <-time.After(50 * time.Millisecond):
+	}
 }
 
 // TestGreedyAccumulate_WithPutBatch verifies greedy accumulate composes with
@@ -161,15 +182,22 @@ func TestGreedyAccumulate_AllItemsDelivered(t *testing.T) {
 
 	var seen sync.Map
 	var count atomic.Int64
+	var dupFound atomic.Bool
 	allDone := make(chan struct{})
+	var allDoneOnce sync.Once
 
+	// Record membership inside fn but do NOT assert here: a require failing on
+	// a background dispatch goroutine calls runtime.Goexit, which would skip the
+	// completion signal below and turn a clear assertion failure into a slow,
+	// misleading top-level timeout. Assert on the test goroutine after draining.
 	b := New[int](size, 50*time.Millisecond, func(batch []*int) {
 		for _, v := range batch {
-			_, dup := seen.LoadOrStore(*v, true)
-			require.False(t, dup, "item %d observed more than once", *v)
+			if _, dup := seen.LoadOrStore(*v, true); dup {
+				dupFound.Store(true)
+			}
 		}
-		if count.Add(int64(len(batch))) == totalItems {
-			close(allDone)
+		if count.Add(int64(len(batch))) >= totalItems {
+			allDoneOnce.Do(func() { close(allDone) })
 		}
 	}, true, WithGreedyAccumulate(true))
 	defer b.Close()
@@ -184,6 +212,9 @@ func TestGreedyAccumulate_AllItemsDelivered(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatalf("expected all %d items delivered, got %d", totalItems, count.Load())
 	}
+
+	require.False(t, dupFound.Load(), "no item should be observed more than once")
+	require.Equal(t, int64(totalItems), count.Load(), "exactly %d items should be delivered", totalItems)
 }
 
 // countingLogger is a minimal Logger that counts Warnf calls, used to assert

--- a/batcher_pr119_review_test.go
+++ b/batcher_pr119_review_test.go
@@ -1,0 +1,368 @@
+package batcher
+
+import (
+	"runtime"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPutBatch_ShutdownRaceDeliversAllItemsAndHonorsSize covers the P0 where a
+// shutdown racing a full SetMaxConcurrent pool mid-split caused appendItems to
+// drop the unconsumed tail of an oversized PutBatch (Close() then returned
+// "success" having silently lost items), and the shutdown drain handed fn a
+// batch larger than the configured size.
+//
+// The single persistent pool worker is occupied by a "prime" batch that blocks
+// in fn, so when the main worker splits the oversized PutBatch it blocks
+// sending the first chunk over the rendezvous channel. Close() then wins the
+// race, forcing the exit=true path. Every accepted item must still reach fn,
+// and no batch may exceed the configured size on any path.
+func TestPutBatch_ShutdownRaceDeliversAllItemsAndHonorsSize(t *testing.T) { //nolint:gocognit // Sequential race-orchestration with guarded fn recording; splitting would obscure the ordering under test
+	const size = 2
+	const groupN = 6 // three size-2 chunks
+
+	primeStarted := make(chan struct{})
+	releasePrime := make(chan struct{})
+	var primeOnce sync.Once
+
+	var mu sync.Mutex
+	var delivered []int
+	maxBatch := 0
+
+	b := New[int](size, time.Hour, func(batch []*int) {
+		// The prime batch carries negative values and blocks to occupy the
+		// sole pool worker; it is not recorded.
+		prime := false
+		for _, v := range batch {
+			if *v < 0 {
+				prime = true
+			}
+		}
+		if prime {
+			primeOnce.Do(func() { close(primeStarted) })
+			<-releasePrime
+			return
+		}
+		mu.Lock()
+		if len(batch) > maxBatch {
+			maxBatch = len(batch)
+		}
+		for _, v := range batch {
+			delivered = append(delivered, *v)
+		}
+		mu.Unlock()
+	}, true)
+	b.SetMaxConcurrent(1)
+
+	// Prime a full size-2 batch so the single pool worker is busy in fn.
+	n1, n2 := -1, -2
+	b.Put(&n1)
+	b.Put(&n2)
+	<-primeStarted
+
+	// Oversized group: the worker pulls it, appends chunk one, and blocks
+	// sending that chunk to the busy pool worker.
+	items := make([]*int, groupN)
+	for i := range items {
+		v := i
+		items[i] = &v
+	}
+	b.PutBatch(items)
+	time.Sleep(100 * time.Millisecond) // let the worker reach the blocked send
+
+	closed := make(chan struct{})
+	go func() {
+		b.Close()
+		close(closed)
+	}()
+	time.Sleep(50 * time.Millisecond) // let Close close done so flushBatch exits
+	close(releasePrime)               // let the prime finish so shutdown can complete
+
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close() did not return")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	sort.Ints(delivered)
+	require.Equal(t, []int{0, 1, 2, 3, 4, 5}, delivered,
+		"every PutBatch item must be delivered even when shutdown races a full pool mid-split")
+	require.LessOrEqual(t, maxBatch, size,
+		"no batch may exceed the configured size, including on the shutdown drain path")
+}
+
+// TestSetMaxConcurrent_NoWorkerLeakOnShutdownRace covers the P0 goroutine leak:
+// when flushBatch took the exit=true shutdown-race branch the worker returned
+// without closing workCh, so the persistent pool goroutines blocked forever on
+// range workCh. After Close returns, goroutine count must settle back.
+func TestSetMaxConcurrent_NoWorkerLeakOnShutdownRace(t *testing.T) { //nolint:gocognit // Sequential race-orchestration setup; each step is a single guarded action
+	const size = 2
+	const poolN = 1 // a full pool, so the split blocks and the shutdown-race exit path is taken
+
+	before := runtime.NumGoroutine()
+
+	primeStarted := make(chan struct{})
+	releasePrime := make(chan struct{})
+	var primeOnce sync.Once
+
+	b := New[int](size, time.Hour, func(batch []*int) {
+		prime := false
+		for _, v := range batch {
+			if *v < 0 {
+				prime = true
+			}
+		}
+		if prime {
+			primeOnce.Do(func() { close(primeStarted) })
+			<-releasePrime
+		}
+	}, true)
+	b.SetMaxConcurrent(poolN)
+
+	n1, n2 := -1, -2
+	b.Put(&n1)
+	b.Put(&n2)
+	<-primeStarted
+
+	items := make([]*int, 6)
+	for i := range items {
+		v := i
+		items[i] = &v
+	}
+	b.PutBatch(items)
+	time.Sleep(100 * time.Millisecond)
+
+	closed := make(chan struct{})
+	go func() {
+		b.Close()
+		close(closed)
+	}()
+	time.Sleep(50 * time.Millisecond)
+	close(releasePrime)
+
+	select {
+	case <-closed:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Close() did not return")
+	}
+
+	// Poll with a plain loop rather than require.Eventually: Eventually runs its
+	// condition on a testify-spawned goroutine, which would itself inflate the
+	// live goroutine count and defeat the comparison.
+	deadline := time.Now().Add(2 * time.Second)
+	for runtime.NumGoroutine() > before && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.LessOrEqual(t, runtime.NumGoroutine(), before,
+		"persistent pool workers must exit after Close (workCh closed on every worker exit)")
+}
+
+// TestGreedyAccumulate_DoesNotStarveTriggerUnderLoad covers the P0 where the
+// greedy-accumulate inner drain loop never returned to the outer select while
+// the channel stayed non-empty, starving Trigger()/timers/Close() for seconds
+// under sustained producer load.
+func TestGreedyAccumulate_DoesNotStarveTriggerUnderLoad(t *testing.T) {
+	// size=1 plus a per-flush cost slower than the producers keeps the channel
+	// continuously non-empty, so the buggy inner loop never hits its empty
+	// (default) arm and never returns to the outer select.
+	b := New[int](1, time.Hour, func(_ []*int) {
+		time.Sleep(time.Millisecond)
+	}, false, WithGreedyAccumulate(true))
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				b.Put(&v)
+			}
+		}()
+	}
+	time.Sleep(100 * time.Millisecond) // ramp the load
+
+	triggered := make(chan struct{})
+	go func() {
+		b.Trigger()
+		close(triggered)
+	}()
+
+	select {
+	case <-triggered:
+	case <-time.After(2 * time.Second):
+		close(stop)
+		wg.Wait()
+		b.Close()
+		t.Fatal("Trigger() starved by the greedy-accumulate inner loop under sustained load")
+	}
+
+	close(stop)
+	wg.Wait()
+	b.Close()
+}
+
+// TestDrainMode_DoesNotStarveTriggerUnderLoad is the drain-mode counterpart of
+// the greedy starvation test: the drain inner loop must also yield to the outer
+// select promptly under sustained load.
+func TestDrainMode_DoesNotStarveTriggerUnderLoad(t *testing.T) {
+	b := New[int](1, time.Hour, func(_ []*int) {
+		time.Sleep(time.Millisecond)
+	}, false)
+	b.SetDrainMode(true)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			v := 0
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				b.Put(&v)
+			}
+		}()
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	triggered := make(chan struct{})
+	go func() {
+		b.Trigger()
+		close(triggered)
+	}()
+
+	select {
+	case <-triggered:
+	case <-time.After(2 * time.Second):
+		close(stop)
+		wg.Wait()
+		b.Close()
+		t.Fatal("Trigger() starved by the drain-mode inner loop under sustained load")
+	}
+
+	close(stop)
+	wg.Wait()
+	b.Close()
+}
+
+// TestPutBatch_SnapshotsCallerSlice covers the P1 where PutBatch retained the
+// caller's slice and read it asynchronously on the worker goroutine. A caller
+// that reuses the slice after the call must not corrupt the enqueued batch.
+//
+// The worker is held busy in fn until after the caller overwrites the slice, so
+// the read/write ordering that exposes the bug is deterministic.
+func TestPutBatch_SnapshotsCallerSlice(t *testing.T) {
+	const size = 10
+
+	gate := make(chan struct{})
+	var gateOnce sync.Once
+	primeStarted := make(chan struct{})
+
+	var mu sync.Mutex
+	var got []int
+
+	b := New[int](size, time.Hour, func(batch []*int) {
+		// First (prime) call blocks so the worker cannot process the PutBatch
+		// envelope until the caller has overwritten the slice.
+		if len(batch) == size {
+			gateOnce.Do(func() { close(primeStarted) })
+			<-gate
+			return
+		}
+		mu.Lock()
+		for _, v := range batch {
+			got = append(got, *v)
+		}
+		mu.Unlock()
+	}, false)
+
+	// Prime a full batch to block the worker in fn.
+	for i := 0; i < size; i++ {
+		v := 1000 + i
+		b.Put(&v)
+	}
+	<-primeStarted
+
+	// Enqueue a sub-size group, then immediately reuse (overwrite) the slice.
+	items := make([]*int, 5)
+	for i := range items {
+		v := i
+		items[i] = &v
+	}
+	b.PutBatch(items)
+	for i := range items {
+		v := 9000 + i
+		items[i] = &v // caller reuses its buffer right after the call
+	}
+
+	close(gate) // release the worker; it now processes the PutBatch envelope
+	time.Sleep(50 * time.Millisecond)
+	b.Trigger()
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	sort.Ints(got)
+	require.Equal(t, []int{0, 1, 2, 3, 4}, got,
+		"PutBatch must snapshot the caller's slice; reusing it after the call must not corrupt the batch")
+
+	b.Close()
+}
+
+// TestNew_PanicsOnNonPositiveSize covers the P2 where size<=0 livelocked
+// appendItems and hung Close(). Construction must reject it outright.
+func TestNew_PanicsOnNonPositiveSize(t *testing.T) {
+	require.Panics(t, func() {
+		New[int](0, time.Hour, func(_ []*int) {}, false)
+	}, "New with size 0 must panic rather than build a batcher that livelocks")
+	require.Panics(t, func() {
+		New[int](-1, time.Hour, func(_ []*int) {}, false)
+	}, "New with negative size must panic")
+}
+
+// TestNewWithPool_PanicsOnNonPositiveSize is the pooled-constructor counterpart.
+func TestNewWithPool_PanicsOnNonPositiveSize(t *testing.T) {
+	require.Panics(t, func() {
+		NewWithPool[int](0, time.Hour, func(_ []*int) {}, false)
+	}, "NewWithPool with size 0 must panic")
+	require.Panics(t, func() {
+		NewWithPool[int](-1, time.Hour, func(_ []*int) {}, false)
+	}, "NewWithPool with negative size must panic")
+}
+
+// TestModeSetters_MutualExclusionUnderConcurrency covers the P2 TOCTOU: drain
+// mode and greedy accumulate are mutually exclusive, and concurrent setters
+// must never leave both enabled.
+func TestModeSetters_MutualExclusionUnderConcurrency(t *testing.T) {
+	for iter := 0; iter < 500; iter++ {
+		b := New[int](10, time.Hour, func(_ []*int) {}, false)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); b.SetDrainMode(true) }()
+		go func() { defer wg.Done(); b.SetGreedyAccumulate(true) }()
+		wg.Wait()
+
+		require.False(t, b.drainMode.Load() && b.greedyAccumulate.Load(),
+			"drain mode and greedy accumulate must never both be enabled (iteration %d)", iter)
+
+		b.Close()
+	}
+}

--- a/batcher_pr119_review_test.go
+++ b/batcher_pr119_review_test.go
@@ -125,17 +125,14 @@ func TestSetMaxConcurrent_NoWorkerLeakOnShutdownRace(t *testing.T) {
 		"persistent pool workers must exit after Close (workCh closed on every worker exit)")
 }
 
-// TestGreedyAccumulate_DoesNotStarveTriggerUnderLoad covers the P0 where the
-// greedy-accumulate inner drain loop never returned to the outer select while
-// the channel stayed non-empty, starving Trigger()/timers/Close() for seconds
-// under sustained producer load.
-func TestGreedyAccumulate_DoesNotStarveTriggerUnderLoad(t *testing.T) {
-	// size=1 plus a per-flush cost slower than the producers keeps the channel
-	// continuously non-empty, so the buggy inner loop never hits its empty
-	// (default) arm and never returns to the outer select.
-	b := New[int](1, time.Hour, func(_ []*int) {
-		time.Sleep(time.Millisecond)
-	}, false, WithGreedyAccumulate(true))
+// assertTriggerNotStarvedUnderLoad drives 32 producers hammering Put() and
+// asserts Trigger() is serviced within a generous bound. Before the fix, the
+// greedy/drain inner loop kept consuming a continuously non-empty channel
+// without returning to the outer select, starving Trigger()/timers/Close() for
+// seconds. b must be a size=1 batcher whose fn is slow enough that producers
+// keep the channel saturated (so the buggy loop never hits its empty arm).
+func assertTriggerNotStarvedUnderLoad(t *testing.T, b *Batcher[int], mode string) {
+	t.Helper()
 
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
@@ -168,7 +165,7 @@ func TestGreedyAccumulate_DoesNotStarveTriggerUnderLoad(t *testing.T) {
 		close(stop)
 		wg.Wait()
 		b.Close()
-		t.Fatal("Trigger() starved by the greedy-accumulate inner loop under sustained load")
+		t.Fatalf("Trigger() starved by the %s inner loop under sustained load", mode)
 	}
 
 	close(stop)
@@ -176,52 +173,25 @@ func TestGreedyAccumulate_DoesNotStarveTriggerUnderLoad(t *testing.T) {
 	b.Close()
 }
 
-// TestDrainMode_DoesNotStarveTriggerUnderLoad is the drain-mode counterpart of
-// the greedy starvation test: the drain inner loop must also yield to the outer
-// select promptly under sustained load.
+// TestGreedyAccumulate_DoesNotStarveTriggerUnderLoad covers the P0 where the
+// greedy-accumulate inner drain loop never returned to the outer select while
+// the channel stayed non-empty, starving Trigger()/timers/Close() for seconds
+// under sustained producer load.
+func TestGreedyAccumulate_DoesNotStarveTriggerUnderLoad(t *testing.T) {
+	b := New[int](1, time.Hour, func(_ []*int) {
+		time.Sleep(time.Millisecond)
+	}, false, WithGreedyAccumulate(true))
+	assertTriggerNotStarvedUnderLoad(t, b, "greedy-accumulate")
+}
+
+// TestDrainMode_DoesNotStarveTriggerUnderLoad is the drain-mode counterpart:
+// the drain inner loop must also yield to the outer select promptly under load.
 func TestDrainMode_DoesNotStarveTriggerUnderLoad(t *testing.T) {
 	b := New[int](1, time.Hour, func(_ []*int) {
 		time.Sleep(time.Millisecond)
 	}, false)
 	b.SetDrainMode(true)
-
-	stop := make(chan struct{})
-	var wg sync.WaitGroup
-	for i := 0; i < 32; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			v := 0
-			for {
-				select {
-				case <-stop:
-					return
-				default:
-				}
-				b.Put(&v)
-			}
-		}()
-	}
-	time.Sleep(100 * time.Millisecond)
-
-	triggered := make(chan struct{})
-	go func() {
-		b.Trigger()
-		close(triggered)
-	}()
-
-	select {
-	case <-triggered:
-	case <-time.After(2 * time.Second):
-		close(stop)
-		wg.Wait()
-		b.Close()
-		t.Fatal("Trigger() starved by the drain-mode inner loop under sustained load")
-	}
-
-	close(stop)
-	wg.Wait()
-	b.Close()
+	assertTriggerNotStarvedUnderLoad(t, b, "drain-mode")
 }
 
 // TestPutBatch_SnapshotsCallerSlice covers the P1 where PutBatch retained the

--- a/batcher_pr119_review_test.go
+++ b/batcher_pr119_review_test.go
@@ -10,32 +10,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestPutBatch_ShutdownRaceDeliversAllItemsAndHonorsSize covers the P0 where a
-// shutdown racing a full SetMaxConcurrent pool mid-split caused appendItems to
-// drop the unconsumed tail of an oversized PutBatch (Close() then returned
-// "success" having silently lost items), and the shutdown drain handed fn a
-// batch larger than the configured size.
-//
-// The single persistent pool worker is occupied by a "prime" batch that blocks
-// in fn, so when the main worker splits the oversized PutBatch it blocks
-// sending the first chunk over the rendezvous channel. Close() then wins the
-// race, forcing the exit=true path. Every accepted item must still reach fn,
-// and no batch may exceed the configured size on any path.
-func TestPutBatch_ShutdownRaceDeliversAllItemsAndHonorsSize(t *testing.T) { //nolint:gocognit // Sequential race-orchestration with guarded fn recording; splitting would obscure the ordering under test
-	const size = 2
-	const groupN = 6 // three size-2 chunks
+// runShutdownRaceScenario drives the shutdown-race exit path shared by the two
+// tests below: it primes the full SetMaxConcurrent pool with a batch that
+// blocks in fn, enqueues an oversized PutBatch that blocks mid-split on the
+// busy pool, then calls Close() concurrently so flushBatch takes its
+// shutdown-race (exit=true) branch. The batcher is fully created AND closed
+// within this call. onBatch is invoked for every non-prime batch handed to fn.
+// The prime batch carries negative values; group items are 0..groupN-1.
+func runShutdownRaceScenario(t *testing.T, size, poolN, groupN int, onBatch func(batch []*int)) {
+	t.Helper()
 
 	primeStarted := make(chan struct{})
 	releasePrime := make(chan struct{})
 	var primeOnce sync.Once
 
-	var mu sync.Mutex
-	var delivered []int
-	maxBatch := 0
-
 	b := New[int](size, time.Hour, func(batch []*int) {
-		// The prime batch carries negative values and blocks to occupy the
-		// sole pool worker; it is not recorded.
 		prime := false
 		for _, v := range batch {
 			if *v < 0 {
@@ -47,25 +36,19 @@ func TestPutBatch_ShutdownRaceDeliversAllItemsAndHonorsSize(t *testing.T) { //no
 			<-releasePrime
 			return
 		}
-		mu.Lock()
-		if len(batch) > maxBatch {
-			maxBatch = len(batch)
-		}
-		for _, v := range batch {
-			delivered = append(delivered, *v)
-		}
-		mu.Unlock()
+		onBatch(batch)
 	}, true)
-	b.SetMaxConcurrent(1)
+	b.SetMaxConcurrent(poolN)
 
-	// Prime a full size-2 batch so the single pool worker is busy in fn.
-	n1, n2 := -1, -2
-	b.Put(&n1)
-	b.Put(&n2)
+	// Prime a full batch so every pool worker is busy in fn.
+	for i := 0; i < size; i++ {
+		v := -(i + 1)
+		b.Put(&v)
+	}
 	<-primeStarted
 
-	// Oversized group: the worker pulls it, appends chunk one, and blocks
-	// sending that chunk to the busy pool worker.
+	// Oversized group: the worker pulls it, appends the first chunk, and blocks
+	// sending that chunk to the busy pool.
 	items := make([]*int, groupN)
 	for i := range items {
 		v := i
@@ -87,6 +70,31 @@ func TestPutBatch_ShutdownRaceDeliversAllItemsAndHonorsSize(t *testing.T) { //no
 	case <-time.After(3 * time.Second):
 		t.Fatal("Close() did not return")
 	}
+}
+
+// TestPutBatch_ShutdownRaceDeliversAllItemsAndHonorsSize covers the P0 where a
+// shutdown racing a full SetMaxConcurrent pool mid-split caused appendItems to
+// drop the unconsumed tail of an oversized PutBatch (Close() then returned
+// "success" having silently lost items), and the shutdown drain handed fn a
+// batch larger than the configured size. Every accepted item must still reach
+// fn, and no batch may exceed the configured size on any path.
+func TestPutBatch_ShutdownRaceDeliversAllItemsAndHonorsSize(t *testing.T) {
+	const size = 2
+
+	var mu sync.Mutex
+	var delivered []int
+	maxBatch := 0
+
+	runShutdownRaceScenario(t, size, 1, 6, func(batch []*int) {
+		mu.Lock()
+		if len(batch) > maxBatch {
+			maxBatch = len(batch)
+		}
+		for _, v := range batch {
+			delivered = append(delivered, *v)
+		}
+		mu.Unlock()
+	})
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -101,56 +109,10 @@ func TestPutBatch_ShutdownRaceDeliversAllItemsAndHonorsSize(t *testing.T) { //no
 // when flushBatch took the exit=true shutdown-race branch the worker returned
 // without closing workCh, so the persistent pool goroutines blocked forever on
 // range workCh. After Close returns, goroutine count must settle back.
-func TestSetMaxConcurrent_NoWorkerLeakOnShutdownRace(t *testing.T) { //nolint:gocognit // Sequential race-orchestration setup; each step is a single guarded action
-	const size = 2
-	const poolN = 1 // a full pool, so the split blocks and the shutdown-race exit path is taken
-
+func TestSetMaxConcurrent_NoWorkerLeakOnShutdownRace(t *testing.T) {
 	before := runtime.NumGoroutine()
 
-	primeStarted := make(chan struct{})
-	releasePrime := make(chan struct{})
-	var primeOnce sync.Once
-
-	b := New[int](size, time.Hour, func(batch []*int) {
-		prime := false
-		for _, v := range batch {
-			if *v < 0 {
-				prime = true
-			}
-		}
-		if prime {
-			primeOnce.Do(func() { close(primeStarted) })
-			<-releasePrime
-		}
-	}, true)
-	b.SetMaxConcurrent(poolN)
-
-	n1, n2 := -1, -2
-	b.Put(&n1)
-	b.Put(&n2)
-	<-primeStarted
-
-	items := make([]*int, 6)
-	for i := range items {
-		v := i
-		items[i] = &v
-	}
-	b.PutBatch(items)
-	time.Sleep(100 * time.Millisecond)
-
-	closed := make(chan struct{})
-	go func() {
-		b.Close()
-		close(closed)
-	}()
-	time.Sleep(50 * time.Millisecond)
-	close(releasePrime)
-
-	select {
-	case <-closed:
-	case <-time.After(3 * time.Second):
-		t.Fatal("Close() did not return")
-	}
+	runShutdownRaceScenario(t, 2, 1, 6, func(_ []*int) {})
 
 	// Poll with a plain loop rather than require.Eventually: Eventually runs its
 	// condition on a testify-spawned goroutine, which would itself inflate the

--- a/batcher_putbatch_test.go
+++ b/batcher_putbatch_test.go
@@ -1,0 +1,307 @@
+package batcher
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// putBatchItem is a minimal test item carrying its own identity so ordering
+// and membership can be verified after a batch fn runs.
+type putBatchItem struct {
+	id int
+}
+
+// TestPutBatch_EmptySliceIsNoOp verifies that calling PutBatch with an empty
+// slice does not enqueue anything and does not trigger a flush.
+func TestPutBatch_EmptySliceIsNoOp(t *testing.T) {
+	var flushes atomic.Int64
+	b := New[putBatchItem](10, time.Hour, func(_ []*putBatchItem) {
+		flushes.Add(1)
+	}, true)
+	defer b.Close()
+
+	b.PutBatch(nil)
+	b.PutBatch([]*putBatchItem{})
+
+	time.Sleep(20 * time.Millisecond)
+	require.Equal(t, int64(0), flushes.Load())
+}
+
+// TestPutBatch_SmallerThanSizeAccumulates verifies that a PutBatch call with
+// fewer items than the configured size does not trigger an immediate flush —
+// it accumulates exactly like N individual Put calls would.
+func TestPutBatch_SmallerThanSizeAccumulates(t *testing.T) {
+	var mu sync.Mutex
+	var batches [][]*putBatchItem
+	b := New[putBatchItem](10, time.Hour, func(batch []*putBatchItem) {
+		mu.Lock()
+		defer mu.Unlock()
+		batches = append(batches, batch)
+	}, true)
+	defer b.Close()
+
+	items := []*putBatchItem{{id: 1}, {id: 2}, {id: 3}}
+	b.PutBatch(items)
+
+	time.Sleep(20 * time.Millisecond)
+	mu.Lock()
+	require.Empty(t, batches, "batch of 3 into a size-10 batcher must not flush before timeout/trigger")
+	mu.Unlock()
+
+	b.Trigger()
+	time.Sleep(20 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, batches, 1)
+	require.Len(t, batches[0], 3)
+}
+
+// TestPutBatch_ExactlySizeFlushesImmediately verifies that a PutBatch call
+// whose length exactly equals the configured size triggers an immediate
+// flush, just as accumulating that many items one at a time would.
+func TestPutBatch_ExactlySizeFlushesImmediately(t *testing.T) {
+	var flushed atomic.Int64
+	done := make(chan struct{})
+	b := New[putBatchItem](5, time.Hour, func(batch []*putBatchItem) {
+		flushed.Store(int64(len(batch)))
+		close(done)
+	}, true)
+	defer b.Close()
+
+	items := make([]*putBatchItem, 5)
+	for i := range items {
+		items[i] = &putBatchItem{id: i}
+	}
+	b.PutBatch(items)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected immediate flush when PutBatch fills exactly to size")
+	}
+	require.Equal(t, int64(5), flushed.Load())
+}
+
+// TestPutBatch_LargerThanSizeSplitsIntoFullBatches verifies the core §6.1
+// design decision: a PutBatch group larger than the configured size is split
+// into multiple batches, each dispatched with exactly `size` items (never
+// more), preserving item order across the split.
+//
+// Uses background=false (synchronous dispatch) so batch *completion* order
+// is deterministic and reflects split order. With background=true and no
+// SetMaxConcurrent, each flushed batch runs on its own unbounded goroutine —
+// cross-batch completion order is never guaranteed there (only order within
+// a single batch is), so asserting it would test scheduler behavior, not
+// appendItems' splitting logic.
+func TestPutBatch_LargerThanSizeSplitsIntoFullBatches(t *testing.T) { //nolint:gocyclo // Sequential select-based assertions on split/flush timing; splitting would obscure the ordering being tested
+	const size = 4
+	const totalItems = 10 // 2 full batches of 4 + a trailing partial batch of 2
+
+	var mu sync.Mutex
+	var batches [][]*putBatchItem
+	flushed := make(chan struct{}, totalItems)
+
+	b := New[putBatchItem](size, time.Hour, func(batch []*putBatchItem) {
+		mu.Lock()
+		// Copy since the batcher may reuse/reset slices after fn returns.
+		cp := make([]*putBatchItem, len(batch))
+		copy(cp, batch)
+		batches = append(batches, cp)
+		mu.Unlock()
+		flushed <- struct{}{}
+	}, false)
+	defer b.Close()
+
+	items := make([]*putBatchItem, totalItems)
+	for i := range items {
+		items[i] = &putBatchItem{id: i}
+	}
+	b.PutBatch(items)
+
+	// Two full batches should flush immediately (split at cap).
+	for i := 0; i < 2; i++ {
+		select {
+		case <-flushed:
+		case <-time.After(time.Second):
+			t.Fatalf("expected split flush #%d to fire immediately", i+1)
+		}
+	}
+
+	// The trailing 2 items should NOT flush yet (under size, no timeout/trigger).
+	select {
+	case <-flushed:
+		t.Fatal("trailing partial batch flushed before size/timeout/trigger")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	b.Trigger()
+	select {
+	case <-flushed:
+	case <-time.After(time.Second):
+		t.Fatal("expected trailing partial batch to flush on Trigger")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, batches, 3)
+	require.Len(t, batches[0], size)
+	require.Len(t, batches[1], size)
+	require.Len(t, batches[2], totalItems-2*size)
+
+	// Verify strict ordering is preserved across the split.
+	var gotIDs []int
+	for _, batch := range batches {
+		for _, item := range batch {
+			gotIDs = append(gotIDs, item.id)
+		}
+	}
+	require.Len(t, gotIDs, totalItems)
+	for i, id := range gotIDs {
+		require.Equal(t, i, id, "item order must be preserved across a PutBatch split")
+	}
+}
+
+// TestPutBatch_MultipleSizesLargerThanBatcherSize verifies a group many
+// multiples of size larger than the batch cap splits into the correct number
+// of full batches with none dropped or duplicated.
+func TestPutBatch_MultipleSizesLargerThanBatcherSize(t *testing.T) {
+	const size = 3
+	const totalItems = 30 // exactly 10 full batches, no remainder
+
+	var seen sync.Map
+	var flushCount atomic.Int64
+	allDone := make(chan struct{})
+
+	b := New[putBatchItem](size, time.Hour, func(batch []*putBatchItem) {
+		require.Len(t, batch, size, "every split batch must be exactly the configured size when the group is an exact multiple")
+		for _, item := range batch {
+			_, alreadySeen := seen.LoadOrStore(item.id, true)
+			require.False(t, alreadySeen, "item %d observed more than once", item.id)
+		}
+		if flushCount.Add(1) == totalItems/size {
+			close(allDone)
+		}
+	}, true)
+	defer b.Close()
+
+	items := make([]*putBatchItem, totalItems)
+	for i := range items {
+		items[i] = &putBatchItem{id: i}
+	}
+	b.PutBatch(items)
+
+	select {
+	case <-allDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("expected %d full batches, got %d", totalItems/size, flushCount.Load())
+	}
+
+	for i := 0; i < totalItems; i++ {
+		_, ok := seen.Load(i)
+		require.True(t, ok, "item %d was never dispatched", i)
+	}
+}
+
+// TestPutBatchCtx_CapturesSpanLinkOnce verifies PutBatchCtx behaves like
+// PutCtx for span-context capture: the context passed in is recorded once
+// per call, not once per item. This test only exercises that PutBatchCtx
+// does not panic and delivers all items — span content itself is covered by
+// the tracer-integration tests elsewhere in this package.
+func TestPutBatchCtx_DeliversAllItems(t *testing.T) {
+	var count atomic.Int64
+	done := make(chan struct{})
+	b := New[putBatchItem](3, time.Hour, func(batch []*putBatchItem) {
+		if count.Add(int64(len(batch))) == 3 {
+			close(done)
+		}
+	}, true)
+	defer b.Close()
+
+	items := []*putBatchItem{{id: 1}, {id: 2}, {id: 3}}
+	b.PutBatchCtx(t.Context(), items)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected PutBatchCtx items to flush at size cap")
+	}
+}
+
+// TestPutBatch_WithPool verifies PutBatch works correctly with the
+// slice-pooling constructor, exercising the pool-return path after a split.
+func TestPutBatch_WithPool(t *testing.T) {
+	const size = 4
+	var flushCount atomic.Int64
+	done := make(chan struct{})
+
+	b := NewWithPool[putBatchItem](size, time.Hour, func(_ []*putBatchItem) {
+		if flushCount.Add(1) == 2 {
+			close(done)
+		}
+	}, true)
+	defer b.Close()
+
+	items := make([]*putBatchItem, 8)
+	for i := range items {
+		items[i] = &putBatchItem{id: i}
+	}
+	b.PutBatch(items)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("expected 2 full-size flushes from an 8-item PutBatch on a size-4 pooled batcher")
+	}
+}
+
+// TestPutBatch_DuringDrainMode verifies that drain mode correctly handles a
+// PutBatch envelope arriving mid-drain, splitting at the size cap the same
+// way the non-drain path does.
+func TestPutBatch_DuringDrainMode(t *testing.T) {
+	const size = 5
+	var mu sync.Mutex
+	var batches [][]int
+	flushed := make(chan struct{}, 10)
+
+	b := New[putBatchItem](size, time.Hour, func(batch []*putBatchItem) {
+		mu.Lock()
+		ids := make([]int, len(batch))
+		for i, it := range batch {
+			ids[i] = it.id
+		}
+		batches = append(batches, ids)
+		mu.Unlock()
+		flushed <- struct{}{}
+	}, true)
+	b.SetDrainMode(true)
+	defer b.Close()
+
+	items := make([]*putBatchItem, 12)
+	for i := range items {
+		items[i] = &putBatchItem{id: i}
+	}
+	b.PutBatch(items)
+
+	// Drain mode should fire as soon as items are available: expect at least
+	// 2 full flushes (10 of the 12 items) plus a drain-fire of the remaining 2.
+	for i := 0; i < 3; i++ {
+		select {
+		case <-flushed:
+		case <-time.After(time.Second):
+			t.Fatalf("expected flush #%d under drain mode", i+1)
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	total := 0
+	for _, batch := range batches {
+		total += len(batch)
+	}
+	require.Equal(t, 12, total, "no items should be lost when a PutBatch group is split under drain mode")
+}

--- a/completion/completion.go
+++ b/completion/completion.go
@@ -1,0 +1,107 @@
+// Package completion provides a group-completion primitive for batched
+// operations: a caller submits N items into one or more batchers and waits
+// once for all N to complete, instead of spawning a goroutine, channel, and
+// timer per item.
+//
+// A Group is intentionally minimal: an atomic counter and a single close
+// channel. The batch dispatcher writes each item's result into a slot the
+// caller owns, then calls Done() on the shared Group. The final Done() closes
+// the channel Wait is parked on, publishing every slot write via the
+// channel-close happens-before edge in the Go memory model.
+//
+// Callers must not read item result slots after Wait returns a non-nil
+// error: a dispatcher may still be writing to a slot after the caller has
+// given up waiting on it, so reading it back concurrently is a data race.
+// Treat a Wait error as "the operation failed" and discard the slots.
+package completion
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+// Group tracks N outstanding batch items belonging to one logical call. The
+// item that makes the counter reach zero closes done exactly once. Item
+// results must be written to caller-owned slots before Done is called for
+// that item; the close(done) edge publishes them to the waiting caller.
+//
+// A Group is used once: create it with NewGroup, call Done exactly once per
+// item, and Wait (or read C()) exactly once (concurrent/repeated Wait calls
+// are safe since they only ever receive from a channel, but a Group is not
+// meant to be reset or reused).
+type Group struct {
+	remaining atomic.Int32
+	done      chan struct{}
+}
+
+// NewGroup creates a Group expecting exactly n calls to Done. n must be >= 0;
+// NewGroup panics if n is negative. A Group created with n == 0 starts
+// already complete — C() is closed and Wait returns immediately.
+func NewGroup(n int32) *Group {
+	if n < 0 {
+		panic(fmt.Sprintf("completion: NewGroup called with negative count %d", n))
+	}
+
+	g := &Group{done: make(chan struct{})}
+	if n == 0 {
+		close(g.done)
+		return g
+	}
+
+	g.remaining.Store(n)
+
+	return g
+}
+
+// Done marks one item complete. It must be called exactly once per item
+// counted in NewGroup's n. Calling it more times than n panics: that is
+// always a programming error (a double-signal on the same item, or a Group
+// sized wrong), and by the time it happens done is already closed, so a
+// second close would panic anyway — this makes the failure message clearer.
+func (g *Group) Done() {
+	switch v := g.remaining.Add(-1); {
+	case v == 0:
+		close(g.done)
+	case v < 0:
+		panic("completion: Group.Done called more times than the count passed to NewGroup")
+	}
+}
+
+// C returns the channel that closes once every item has completed. Prefer
+// Wait for the common case; C is exposed for callers that need to fold group
+// completion into a larger select statement.
+func (g *Group) C() <-chan struct{} {
+	return g.done
+}
+
+// Wait blocks until every item has completed, ctx is done, or timeout
+// elapses — whichever happens first. A timeout <= 0 disables the timeout arm
+// entirely (no timer is allocated), so Wait then blocks on ctx and
+// completion only, mirroring an unbounded per-item channel receive.
+//
+// On a non-nil return, the caller must not read item result slots: a
+// dispatcher may still be writing to them after Wait has given up.
+func (g *Group) Wait(ctx context.Context, timeout time.Duration) error {
+	if timeout <= 0 {
+		select {
+		case <-g.done:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-g.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return fmt.Errorf("completion: Wait timed out after %s", timeout)
+	}
+}

--- a/completion/completion.go
+++ b/completion/completion.go
@@ -17,10 +17,15 @@ package completion
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
 )
+
+// ErrWaitTimeout is returned by Wait when timeout elapses before every item
+// in the Group completes. Use errors.Is to check for it.
+var ErrWaitTimeout = errors.New("completion: Wait timed out")
 
 // Group tracks N outstanding batch items belonging to one logical call. The
 // item that makes the counter reach zero closes done exactly once. Item
@@ -102,6 +107,6 @@ func (g *Group) Wait(ctx context.Context, timeout time.Duration) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-timer.C:
-		return fmt.Errorf("completion: Wait timed out after %s", timeout)
+		return fmt.Errorf("%w after %s", ErrWaitTimeout, timeout)
 	}
 }

--- a/completion/completion_benchmark_test.go
+++ b/completion/completion_benchmark_test.go
@@ -10,6 +10,11 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// errBenchmarkTimeout simulates the timeout error a real per-item protocol
+// site would return; a static error (rather than errors.New at the call
+// site) avoids allocating a new error value on every simulated timeout.
+var errBenchmarkTimeout = errors.New("timeout")
+
 // BenchmarkOldPerItemProtocol simulates the pre-Group completion protocol
 // this package replaces: one goroutine, one buffered channel, and one timer
 // per item, fanned out via an errgroup and joined with g.Wait.
@@ -32,7 +37,7 @@ func BenchmarkOldPerItemProtocol(b *testing.B) {
 				case err := <-errCh:
 					return err
 				case <-timer.C:
-					return errors.New("timeout")
+					return errBenchmarkTimeout
 				}
 			})
 		}

--- a/completion/completion_benchmark_test.go
+++ b/completion/completion_benchmark_test.go
@@ -1,0 +1,86 @@
+package completion
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// BenchmarkOldPerItemProtocol simulates the pre-Group completion protocol
+// this package replaces: one goroutine, one buffered channel, and one timer
+// per item, fanned out via an errgroup and joined with g.Wait.
+func BenchmarkOldPerItemProtocol(b *testing.B) {
+	const itemsPerCall = 8
+
+	for b.Loop() {
+		var g errgroup.Group
+
+		for i := 0; i < itemsPerCall; i++ {
+			g.Go(func() error {
+				errCh := make(chan error, 1)
+				timer := time.NewTimer(time.Second)
+				defer timer.Stop()
+
+				// Simulate the dispatcher completing the item.
+				go func() { errCh <- nil }()
+
+				select {
+				case err := <-errCh:
+					return err
+				case <-timer.C:
+					return errors.New("timeout")
+				}
+			})
+		}
+
+		_ = g.Wait()
+	}
+}
+
+// BenchmarkGroupCompletionProtocol measures the same itemsPerCall items
+// completed via one shared Group and a single Wait — no per-item goroutine,
+// channel, or timer.
+func BenchmarkGroupCompletionProtocol(b *testing.B) {
+	const itemsPerCall = 8
+
+	for b.Loop() {
+		g := NewGroup(itemsPerCall)
+
+		// Simulate the dispatcher completing every item from one goroutine,
+		// as a batch dispatcher does after a single BatchOperate call.
+		go func() {
+			for i := 0; i < itemsPerCall; i++ {
+				g.Done()
+			}
+		}()
+
+		_ = g.Wait(context.Background(), time.Second)
+	}
+}
+
+// BenchmarkGroupCompletionProtocol_ConcurrentDone measures the case where
+// each item is completed from its own goroutine (worst case for the Group —
+// still just one atomic decrement each, no channel/timer).
+func BenchmarkGroupCompletionProtocol_ConcurrentDone(b *testing.B) {
+	const itemsPerCall = 8
+
+	for b.Loop() {
+		g := NewGroup(itemsPerCall)
+
+		var wg sync.WaitGroup
+		for i := 0; i < itemsPerCall; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				g.Done()
+			}()
+		}
+
+		_ = g.Wait(context.Background(), time.Second)
+		wg.Wait()
+	}
+}

--- a/completion/completion_test.go
+++ b/completion/completion_test.go
@@ -1,0 +1,175 @@
+package completion
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewGroup_ZeroItemsStartsClosed(t *testing.T) {
+	g := NewGroup(0)
+
+	select {
+	case <-g.C():
+	default:
+		t.Fatal("expected done channel to start closed for n=0")
+	}
+
+	require.NoError(t, g.Wait(context.Background(), time.Second))
+}
+
+func TestNewGroup_NegativeCountPanics(t *testing.T) {
+	require.Panics(t, func() {
+		NewGroup(-1)
+	})
+}
+
+func TestGroup_DoneClosesAfterAllComplete(t *testing.T) {
+	g := NewGroup(3)
+
+	select {
+	case <-g.C():
+		t.Fatal("done should not be closed yet")
+	default:
+	}
+
+	g.Done()
+	g.Done()
+
+	select {
+	case <-g.C():
+		t.Fatal("done should not be closed until all items complete")
+	default:
+	}
+
+	g.Done()
+
+	select {
+	case <-g.C():
+	default:
+		t.Fatal("done should be closed after all items complete")
+	}
+}
+
+func TestGroup_DoneCalledTooManyTimesPanics(t *testing.T) {
+	g := NewGroup(1)
+	g.Done()
+
+	require.Panics(t, func() {
+		g.Done()
+	})
+}
+
+func TestGroup_WaitReturnsNilOnCompletion(t *testing.T) {
+	g := NewGroup(1)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		g.Done()
+	}()
+
+	err := g.Wait(context.Background(), time.Second)
+	require.NoError(t, err)
+}
+
+func TestGroup_WaitReturnsErrorOnContextCancel(t *testing.T) {
+	g := NewGroup(1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	err := g.Wait(ctx, time.Second)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// Item never completed; a late Done must not panic or block.
+	g.Done()
+}
+
+func TestGroup_WaitReturnsErrorOnTimeout(t *testing.T) {
+	g := NewGroup(1)
+
+	err := g.Wait(context.Background(), 10*time.Millisecond)
+	require.Error(t, err)
+
+	// Item never completed; a late Done must not panic or block.
+	g.Done()
+}
+
+func TestGroup_WaitWithZeroTimeoutBlocksUntilDone(t *testing.T) {
+	g := NewGroup(1)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		g.Done()
+	}()
+
+	// timeout <= 0 means no timer arm; only ctx/done can unblock this.
+	err := g.Wait(context.Background(), 0)
+	require.NoError(t, err)
+}
+
+func TestGroup_WaitWithZeroTimeoutRespectsContext(t *testing.T) {
+	g := NewGroup(1)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+
+	err := g.Wait(ctx, 0)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+
+	g.Done()
+}
+
+func TestGroup_ConcurrentDoneIsRace_Free(t *testing.T) {
+	const n = 1000
+	g := NewGroup(n)
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			g.Done()
+		}()
+	}
+	wg.Wait()
+
+	err := g.Wait(context.Background(), time.Second)
+	require.NoError(t, err)
+}
+
+func TestGroup_ManyGroupsManyItemsNoRace(t *testing.T) {
+	const groups = 50
+	const itemsPerGroup = 200
+
+	var wg sync.WaitGroup
+	for i := 0; i < groups; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			g := NewGroup(itemsPerGroup)
+			var innerWg sync.WaitGroup
+			for j := 0; j < itemsPerGroup; j++ {
+				innerWg.Add(1)
+				go func() {
+					defer innerWg.Done()
+					g.Done()
+				}()
+			}
+			innerWg.Wait()
+			require.NoError(t, g.Wait(context.Background(), time.Second))
+		}()
+	}
+	wg.Wait()
+}

--- a/completion/completion_test.go
+++ b/completion/completion_test.go
@@ -97,6 +97,7 @@ func TestGroup_WaitReturnsErrorOnTimeout(t *testing.T) {
 
 	err := g.Wait(context.Background(), 10*time.Millisecond)
 	require.Error(t, err)
+	require.ErrorIs(t, err, ErrWaitTimeout)
 
 	// Item never completed; a late Done must not panic or block.
 	g.Done()
@@ -153,6 +154,11 @@ func TestGroup_ManyGroupsManyItemsNoRace(t *testing.T) {
 	const groups = 50
 	const itemsPerGroup = 200
 
+	// Wait errors are collected here and asserted on the test goroutine
+	// (rather than inside the spawned goroutines) so require's t.FailNow
+	// only ever runs on the goroutine executing the test function.
+	errs := make(chan error, groups)
+
 	var wg sync.WaitGroup
 	for i := 0; i < groups; i++ {
 		wg.Add(1)
@@ -168,8 +174,13 @@ func TestGroup_ManyGroupsManyItemsNoRace(t *testing.T) {
 				}()
 			}
 			innerWg.Wait()
-			require.NoError(t, g.Wait(context.Background(), time.Second))
+			errs <- g.Wait(context.Background(), time.Second)
 		}()
 	}
 	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.NoError(t, err)
+	}
 }

--- a/observability.go
+++ b/observability.go
@@ -85,6 +85,12 @@ type config struct {
 	metricsBound BoundMetrics
 	tracer       trace.Tracer
 	name         string
+	// greedyAccumulate seeds the Batcher's runtime greedyAccumulate flag at
+	// construction time. It is a plain bool (not atomic) because config is
+	// fully resolved by applyOptions before the worker goroutine starts and
+	// is never mutated afterward — see SetGreedyAccumulate for the
+	// post-construction, mutually-exclusive-with-drain-mode toggle.
+	greedyAccumulate bool
 }
 
 func defaultConfig() *config {
@@ -156,6 +162,17 @@ func WithName(name string) Option {
 		if name != "" {
 			c.name = name
 		}
+	}
+}
+
+// WithGreedyAccumulate seeds the Batcher's greedy-accumulate flag at
+// construction time — a convenience equivalent to calling
+// SetGreedyAccumulate(enabled) immediately after construction, before any
+// items are enqueued. See SetGreedyAccumulate for the full behavior and its
+// mutual exclusion with drain mode.
+func WithGreedyAccumulate(enabled bool) Option {
+	return func(c *config) {
+		c.greedyAccumulate = enabled
 	}
 }
 

--- a/prometheus_metrics_test.go
+++ b/prometheus_metrics_test.go
@@ -165,6 +165,32 @@ func TestPrometheusMetricsPutBatchCountsItems(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "PutBatch of 7 items must increment enqueued_total by 7")
 }
 
+// TestPrometheusMetricsDrainModeSplitReason verifies that when an oversized
+// PutBatch is split during a drain-mode cycle, the resulting full batches are
+// labeled with the driving cycle's reason (drain) rather than always "size".
+func TestPrometheusMetricsDrainModeSplitReason(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewPrometheusMetrics(reg, "test", "batch")
+
+	b := New[int](3, time.Hour, func(_ []*int) {}, false, WithName("alpha"), WithMetrics(m))
+	b.SetDrainMode(true)
+
+	items := make([]*int, 9) // exactly three size-3 splits
+	for i := range items {
+		v := i
+		items[i] = &v
+	}
+	b.PutBatch(items)
+
+	require.Eventually(t, func() bool {
+		return counterValue(t, reg, "test_batch_batches_total", "batcher", "alpha", "reason", ReasonDrain) == 3
+	}, time.Second, 10*time.Millisecond, "drain-mode PutBatch splits must be labeled drain")
+	assert.InDelta(t, 0, counterValue(t, reg, "test_batch_batches_total", "batcher", "alpha", "reason", ReasonSize), floatEpsilon,
+		"no split should be labeled size during a drain cycle")
+
+	b.Close()
+}
+
 func TestPrometheusMetricsSharedAcrossBatchers(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := NewPrometheusMetrics(reg, "svc", "batcher")

--- a/prometheus_metrics_test.go
+++ b/prometheus_metrics_test.go
@@ -143,6 +143,28 @@ func TestPrometheusMetricsRecordsBatcherActivity(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+// TestPrometheusMetricsPutBatchCountsItems verifies enqueued_total counts every
+// item of a PutBatch group, not one per multi-item envelope — the counter's
+// help text is "Total items submitted to the batcher".
+func TestPrometheusMetricsPutBatchCountsItems(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewPrometheusMetrics(reg, "test", "batch")
+
+	b := New[int](100, time.Hour, func(_ []*int) {}, true, WithName("alpha"), WithMetrics(m))
+	defer b.Close()
+
+	items := make([]*int, 7)
+	for i := range items {
+		v := i
+		items[i] = &v
+	}
+	b.PutBatch(items)
+
+	require.Eventually(t, func() bool {
+		return counterValue(t, reg, "test_batch_enqueued_total", "batcher", "alpha") == 7
+	}, time.Second, 10*time.Millisecond, "PutBatch of 7 items must increment enqueued_total by 7")
+}
+
 func TestPrometheusMetricsSharedAcrossBatchers(t *testing.T) {
 	reg := prometheus.NewRegistry()
 	m := NewPrometheusMetrics(reg, "svc", "batcher")


### PR DESCRIPTION
## Summary

Three additive, backward-compatible features aimed at reducing per-item completion overhead for high-throughput batch callers (teranode's UTXO store/block-assembly/propagation batchers are the motivating use case, but nothing here is teranode-specific):

- **`completion` subpackage**: a `Group` primitive — one atomic counter and one `close(done)` — that replaces the common "goroutine + buffered channel + timer per item, joined with an errgroup" completion pattern. Benchmark: ~8x lower latency and ~8x fewer allocations per call for 8 items/call (5512ns/57 allocs -> 675ns/7 allocs).
- **`PutBatch`/`PutBatchCtx`**: enqueue a whole group of items in a single channel send instead of one `Put` per item. The collector splits an over-sized group at the configured batch size — each full split dispatches immediately and in order, with at most one trailing partial batch continuing to accumulate normally. Batch size is always honored.
- **`WithGreedyAccumulate`/`SetGreedyAccumulate`**: after receiving an item, opportunistically drain additional already-queued items into the same batch via a non-blocking receive, instead of re-entering the full 5-arm select per item. Unlike drain mode, it never fires early. Benchmark under sustained load: ~3.4x throughput (198ns/op -> 58ns/op per `Put`).

Implementing `PutBatch` required refactoring `worker()`'s goto-based dispatch (the former `saveBatch` label) into a callable `flushBatch` method, since a single `PutBatch` envelope can now trigger more than one flush without leaving the select loop between them (`appendItems`). The full existing test suite (drain mode, tick mode, `SetMaxConcurrent`, shutdown drain, fuzz) passes unmodified, confirming single-item `Put`/`PutCtx` behavior is unchanged.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `staticcheck ./...` — clean
- [x] `go test -race ./...` — full suite green, run repeatedly with cache cleared
- [x] `go test -fuzz FuzzBatcherPut` / `FuzzBatcherConcurrent` — 30s+ each, no crashes, both before and after the `WithGreedyAccumulate` addition
- [x] New tests: `completion/completion_test.go`, `batcher_putbatch_test.go`, `batcher_greedy_accumulate_test.go` covering split-at-cap, ordering, drain-mode interaction, timer re-arming across mid-call flushes, mutual exclusion with drain mode in both directions
- [x] New benchmarks: `completion/completion_benchmark_test.go`, `batcher_greedy_accumulate_benchmark_test.go`